### PR TITLE
chore: release v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,43 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.16] - 2026-02-22
+
+### What changed for users
+
+`harness-mem doctor --fix` now recovers environments missing ripgrep (`rg`) by automatically installing it via Homebrew during setup repair.
+
+### Added
+
+- Automatic `ripgrep` install path in dependency bootstrap (`brew install ripgrep`) when `rg` is missing.
+
+### Changed
+
+- Setup dependency failure hint now includes `ripgrep`.
+- Troubleshooting docs now include `ripgrep` in required dependency list.
+
+### Fixed
+
+- Prevented `doctor_post_check` false-failures caused by `rg: command not found` in hook/wiring checks.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- No migration is required.
+
+### Verification
+
+- `bash -n scripts/harness-mem`
+- `bun test tests/doctor-json-contract.test.ts tests/readme-plans-rules.test.ts`
+- `npm pack --dry-run`
+
 ## [0.1.15] - 2026-02-22
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,18 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.16] - 2026-02-22
+
+### ユーザー向け要約
+
+- `harness-mem doctor --fix` 実行時に `rg`（ripgrep）が未導入でも、Homebrew で自動導入して復旧を継続できるように改善。
+- これにより `rg: command not found` 起因の `doctor_post_check` 失敗を回避。
+
+### 補足
+
+- 依存関係の案内文にも `ripgrep` を追加。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.15] - 2026-02-22
 
 ### ユーザー向け要約

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ npx -y --package @chachamaru127/harness-mem harness-mem setup
 
 ### 2) `doctor` reports missing dependencies
 
-Install required tools (`bun`, `node`, `curl`, `jq`) and run:
+Install required tools (`bun`, `node`, `curl`, `jq`, `ripgrep`) and run:
 
 ```bash
 harness-mem doctor

--- a/docs/harness-mem-setup.md
+++ b/docs/harness-mem-setup.md
@@ -461,6 +461,7 @@ This will:
 | `bun is missing` | bun 未インストール | `brew install bun` または https://bun.sh |
 | `jq is missing` | jq 未インストール | `brew install jq` |
 | `node is missing` | Node.js 未インストール | `brew install node` |
+| `rg (ripgrep) is missing` | ripgrep 未インストール | `brew install ripgrep`（setup時は自動導入を試行） |
 | `Codex notify wiring is missing` | Codex 配線なし | `harness-mem setup --platform codex` |
 | `Cursor hooks wiring is incomplete` | Cursor 配線なし | `harness-mem setup --platform cursor` |
 | `Claude MCP wiring is missing` | Claude 配線なし | `harness-mem setup --platform claude` |
@@ -507,7 +508,7 @@ harness-mem doctor --json
 依存コマンドのインストール:
 
 ```bash
-brew install bun curl jq node
+brew install bun curl jq node ripgrep
 ```
 
 Codex 配線の手動確認:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {

--- a/scripts/harness-mem
+++ b/scripts/harness-mem
@@ -579,6 +579,34 @@ check_cmd() {
   command -v "$name" >/dev/null 2>&1
 }
 
+ensure_ripgrep() {
+  if check_cmd rg; then
+    return 0
+  fi
+
+  warn "ripgrep (rg) is missing"
+  if check_cmd brew; then
+    log "Installing ripgrep via Homebrew..."
+    if brew install ripgrep; then
+      hash -r
+      if check_cmd rg; then
+        log "ripgrep installed: $(command -v rg)"
+        return 0
+      fi
+
+      local rg_prefix
+      rg_prefix="$(brew --prefix ripgrep 2>/dev/null || true)"
+      if [ -n "$rg_prefix" ] && [ -d "$rg_prefix/bin" ]; then
+        fail "ripgrep installed but rg is not on PATH. Add ${rg_prefix}/bin to PATH and retry."
+      fi
+      fail "ripgrep installation finished but rg command is still unavailable."
+    fi
+    fail "Failed to install ripgrep automatically. Install it manually: brew install ripgrep"
+  fi
+
+  fail "Required command not found: rg (ripgrep). Install it first (macOS: brew install ripgrep)."
+}
+
 get_cursor_hooks_command() {
   printf '%s' "bash ${HOME}/.cursor/hooks/memory-cursor-event.sh"
 }
@@ -589,6 +617,7 @@ ensure_dependencies() {
   require_cmd jq
   require_cmd node
   require_cmd npm
+  ensure_ripgrep
 }
 
 ensure_version_dependencies() {
@@ -2039,6 +2068,10 @@ doctor_impl() {
   fi
 
   # 依存コマンドチェック
+  if [ "$FIX_MODE" -eq 1 ]; then
+    ensure_ripgrep
+  fi
+
   if check_cmd bun; then
     _doctor_record "bun" "ok" ""
   else
@@ -2072,6 +2105,13 @@ doctor_impl() {
   else
     warn "npm is missing"
     _doctor_record "npm" "missing" "brew install node"
+    failed=1
+  fi
+  if check_cmd rg; then
+    _doctor_record "rg" "ok" ""
+  else
+    warn "rg (ripgrep) is missing"
+    _doctor_record "rg" "missing" "brew install ripgrep"
     failed=1
   fi
 
@@ -2344,7 +2384,7 @@ setup_impl() {
     _setup_record "dependencies" "ok" ""
   else
     ensure_dependencies  # エラーメッセージを出す
-    _setup_record "dependencies" "failed" "brew install bun curl jq node"
+    _setup_record "dependencies" "failed" "brew install bun curl jq node ripgrep"
     _setup_print_repair_suggestions "${SETUP_RESULTS[@]}"
     return 1
   fi


### PR DESCRIPTION
## Summary\n- auto-install ripgrep during dependency bootstrap when missing\n- ensure doctor --fix installs ripgrep before wiring checks\n- include ripgrep in dependency docs and troubleshooting hints\n- bump package version to 0.1.16\n\n## Verification\n- bash -n scripts/harness-mem\n- bun test tests/doctor-json-contract.test.ts tests/readme-plans-rules.test.ts\n- npm pack --dry-run\n- simulated doctor --fix in rg-missing env confirms Homebrew auto-install path\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート v0.1.16

* **新機能**
  * harness-mem doctor --fix 実行時に、Homebrew経由でripgrepが自動的にインストールされるようになりました。

* **ドキュメント**
  * セットアップガイドと必要なツール一覧にripgrepの要件を追加しました。

* **Chores**
  * バージョンを0.1.16にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->