### PR TITLE
chore: release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,46 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.17] - 2026-02-22
+
+### What changed for users
+
+`harness-mem setup` now installs and starts the Mem UI alongside the API daemon, so first-time setup immediately provides both endpoints.
+
+### Added
+
+- npm package now ships Mem UI runtime files (`harness-mem-ui/src/*`) required for standalone UI server startup.
+- `harness-memd start` now launches Mem UI on `HARNESS_MEM_UI_PORT` (default `37901`) when `HARNESS_MEM_ENABLE_UI` is enabled.
+
+### Changed
+
+- setup success logs now show both API (`:37888`) and Mem UI (`:37901`) URLs.
+- setup/docs now document that Mem UI is auto-started by default.
+
+### Fixed
+
+- Removed first-setup UX gap where users had to manually clone the repository and run `harness-mem-ui` separately.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- No migration is required.
+- To disable auto UI startup explicitly: `HARNESS_MEM_ENABLE_UI=false`.
+
+### Verification
+
+- `bash -n scripts/harness-memd`
+- `bash -n scripts/harness-mem`
+- `bun test tests/harness-memd-guardrails.test.ts`
+- `npm pack --dry-run`
+
 ## [0.1.16] - 2026-02-22
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,19 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.17] - 2026-02-22
+
+### ユーザー向け要約
+
+- `harness-mem setup` で API だけでなく Mem UI も同時に導入・起動されるように改善。
+- 初回セットアップ直後から `http://127.0.0.1:37901` にアクセス可能になり、UIの手動セットアップが不要に。
+
+### 補足
+
+- npm 配布物に UI 実行ファイル群（`harness-mem-ui/src/*`）を同梱。
+- 自動起動を止めたい場合は `HARNESS_MEM_ENABLE_UI=false` を設定。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.16] - 2026-02-22
 
 ### ユーザー向け要約

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ harness-mem doctor --platform codex,cursor,claude
 harness-mem doctor --fix --platform codex,cursor,claude
 ```
 
+```bash
+# メモリUI（setupで自動起動）
+open http://127.0.0.1:37901
+```
+
 ### setup 失敗時の復旧
 
 `setup` が失敗した場合、失敗ステップと修復コマンドが自動表示されます:
@@ -102,7 +107,7 @@ Execution order:
 
 | Capability | What it gives you |
 |---|---|
-| `setup` | Automated wiring for Codex, OpenCode, Cursor, Claude MCP, and runtime startup |
+| `setup` | Automated wiring for Codex, OpenCode, Cursor, Claude MCP, plus daemon + Mem UI startup |
 | `doctor` | Deterministic health and wiring checks with optional repair (`--fix`), structured JSON output (`--json`) |
 | `versions` | Local/Upstream version snapshot + status tracking for all supported tools |
 | `smoke` | End-to-end privacy and retrieval sanity check |

--- a/docs/harness-mem-setup.md
+++ b/docs/harness-mem-setup.md
@@ -84,13 +84,14 @@ harness-mem setup
 
 `harness-mem setup` performs:
 
-1. Dependency checks (`bun`, `node`, `curl`, `jq`)
+1. Dependency checks (`bun`, `node`, `curl`, `jq`, `ripgrep`)
 2. Tool wiring (Codex, OpenCode, Cursor, Claude, Antigravity)
-3. Daemon start (`harness-memd`)
-4. Smoke test
-5. Search quality guard
-6. Optional Claude-mem import + optional Claude-mem stop
-7. Version snapshot (local vs upstream)
+3. Daemon start (`harness-memd`, API: `127.0.0.1:37888`)
+4. Mem UI start (`127.0.0.1:37901`)
+5. Smoke test
+6. Search quality guard
+7. Optional Claude-mem import + optional Claude-mem stop
+8. Version snapshot (local vs upstream)
 
 When `--platform` is omitted, setup is interactive:
 
@@ -258,6 +259,7 @@ Options:
 - `HARNESS_MEM_HOST` (default: `127.0.0.1`)
 - `HARNESS_MEM_PORT` (default: `37888`)
 - `HARNESS_MEM_UI_PORT` (default: `37901`)
+- `HARNESS_MEM_ENABLE_UI` (default: `true`)
 - `HARNESS_MEM_LOG_MAX_BYTES` (default: `5242880`, 5MB)
 - `HARNESS_MEM_LOG_ROTATE_KEEP` (default: `5`)
 
@@ -415,15 +417,22 @@ scripts/harness-mem setup
 scripts/harness-mem doctor
 ```
 
-## 10. Mem UI (Standalone)
+## 10. Mem UI
+
+`harness-mem setup` / `harness-memd start` で UI は自動起動します。
+
+```bash
+# default
+open http://127.0.0.1:37901
+```
+
+手動で standalone 起動したい場合:
 
 ```bash
 cd /Users/tachibanashuuta/Desktop/Code/CC-harness/harness-mem/harness-mem-ui
 bun install
 bun run dev
 ```
-
-Default URL: `http://127.0.0.1:37901`
 
 ## 11. Uninstall and Cleanup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {
@@ -34,6 +34,8 @@
     "hooks/",
     "codex/",
     "opencode/plugins/",
+    "harness-mem-ui/src/",
+    "harness-mem-ui/package.json",
     ".cursor/hooks.json.example",
     ".cursor/hooks/"
   ],

--- a/scripts/harness-mem
+++ b/scripts/harness-mem
@@ -52,6 +52,7 @@ VERSION_CHECK_IN_SETUP=1
 
 MEM_HOST="${HARNESS_MEM_HOST:-127.0.0.1}"
 MEM_PORT="${HARNESS_MEM_PORT:-37888}"
+MEM_UI_PORT="${HARNESS_MEM_UI_PORT:-37901}"
 STATE_DIR="${HARNESS_MEM_HOME:-$HOME/.harness-mem}"
 DB_PATH="${HARNESS_MEM_DB_PATH:-$STATE_DIR/harness-mem.db}"
 VERSIONS_DIR="${STATE_DIR}/versions"
@@ -2444,6 +2445,7 @@ setup_impl() {
     if start_daemon 2>/dev/null; then
       _setup_record "daemon_start" "ok" ""
       log "Daemon started: http://${MEM_HOST}:${MEM_PORT}"
+      log "Mem UI started: http://${MEM_HOST}:${MEM_UI_PORT}"
     else
       start_daemon || true
       _setup_record "daemon_start" "failed" "harness-memd start"

--- a/scripts/harness-memd
+++ b/scripts/harness-memd
@@ -36,16 +36,37 @@ HOST="${HARNESS_MEM_HOST:-127.0.0.1}"
 PORT="${HARNESS_MEM_PORT:-37888}"
 UI_PORT="${HARNESS_MEM_UI_PORT:-37901}"
 HEALTH_URL="http://${HOST}:${PORT}/health"
+UI_CONTEXT_URL="http://${HOST}:${UI_PORT}/api/context"
 START_TIMEOUT_SEC="${HARNESS_MEM_START_TIMEOUT_SEC:-20}"
 STOP_TIMEOUT_SEC="${HARNESS_MEM_STOP_TIMEOUT_SEC:-5}"
 LOG_MAX_BYTES="${HARNESS_MEM_LOG_MAX_BYTES:-5242880}"
 LOG_ROTATE_KEEP="${HARNESS_MEM_LOG_ROTATE_KEEP:-5}"
+UI_ENABLED_RAW="${HARNESS_MEM_ENABLE_UI:-true}"
 QUIET="false"
 
 DAEMON_ENTRY="${REPO_ROOT}/memory-server/src/index.ts"
 UI_ENTRY="${REPO_ROOT}/harness-mem-ui/src/server.ts"
 PROJECT_ROOT="${HARNESS_MEM_CODEX_PROJECT_ROOT:-$PWD}"
 CONFIG_PATH="${STATE_DIR}/config.json"
+
+to_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_trueish() {
+  case "$(to_lower "$1")" in
+    1|true|yes|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_ui_enabled() {
+  is_trueish "$UI_ENABLED_RAW"
+}
 
 read_backend_mode() {
   if [ -f "$CONFIG_PATH" ]; then
@@ -229,6 +250,21 @@ wait_for_health() {
   return 1
 }
 
+wait_for_ui() {
+  local retries=$((START_TIMEOUT_SEC * 2))
+  local attempt=0
+
+  while [ "$attempt" -lt "$retries" ]; do
+    if is_ui_reachable; then
+      return 0
+    fi
+    sleep 0.5
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
 is_health_reachable() {
   local response
   response="$(curl --silent --show-error --max-time 1 "$HEALTH_URL" 2>/dev/null || true)"
@@ -238,6 +274,21 @@ is_health_reachable() {
 
   if command -v jq >/dev/null 2>&1; then
     printf '%s' "$response" | jq -e '.ok == true and (.items | type == "array")' >/dev/null 2>&1
+    return $?
+  fi
+
+  printf '%s' "$response" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'
+}
+
+is_ui_reachable() {
+  local response
+  response="$(curl --silent --show-error --max-time 1 "$UI_CONTEXT_URL" 2>/dev/null || true)"
+  if [ -z "$response" ]; then
+    return 1
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$response" | jq -e '.ok == true' >/dev/null 2>&1
     return $?
   fi
 
@@ -324,19 +375,24 @@ discover_ui_pid_from_port() {
   return 1
 }
 
-discover_listener_pid_from_port() {
+discover_listener_pid_for_port() {
+  local target_port="$1"
   if ! command -v lsof >/dev/null 2>&1; then
     return 1
   fi
 
   local pid
-  pid="$(lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n1 || true)"
+  pid="$(lsof -nP -tiTCP:"$target_port" -sTCP:LISTEN 2>/dev/null | head -n1 || true)"
   if [ -z "$pid" ]; then
     return 1
   fi
 
   echo "$pid"
   return 0
+}
+
+discover_listener_pid_from_port() {
+  discover_listener_pid_for_port "$PORT"
 }
 
 read_process_args() {
@@ -389,6 +445,122 @@ refresh_pid_file_from_runtime() {
   return 0
 }
 
+start_ui() {
+  if ! is_ui_enabled; then
+    rm -f "$UI_PID_FILE"
+    log "harness-mem-ui startup disabled (HARNESS_MEM_ENABLE_UI=false)"
+    return 0
+  fi
+
+  if [ ! -f "$UI_ENTRY" ]; then
+    echo "[ERR] harness-mem-ui entry not found: $UI_ENTRY" >&2
+    return 1
+  fi
+
+  if ! command -v bun >/dev/null 2>&1; then
+    echo "[ERR] bun is required but not found (for harness-mem-ui)" >&2
+    return 1
+  fi
+
+  local runtime_pid
+  runtime_pid="$(discover_ui_pid_from_port || true)"
+  if [ -n "$runtime_pid" ]; then
+    echo "$runtime_pid" > "$UI_PID_FILE"
+    if wait_for_ui; then
+      log "harness-mem-ui already running (pid=${runtime_pid}, port=${UI_PORT})"
+      return 0
+    fi
+    warn "UI listener exists on port ${UI_PORT} (pid=${runtime_pid}) but /api/context is unreachable"
+    warn "Refusing to spawn duplicate UI process. Check runtime with: scripts/harness-memd doctor"
+    return 1
+  fi
+
+  local listener_pid
+  listener_pid="$(discover_listener_pid_for_port "$UI_PORT" || true)"
+  if [ -n "$listener_pid" ]; then
+    local listener_args
+    listener_args="$(read_process_args "$listener_pid")"
+    warn "UI port ${UI_PORT} is already in use by another process (pid=${listener_pid})"
+    if [ -n "$listener_args" ]; then
+      warn "Process args: ${listener_args}"
+    fi
+    warn "Resolve the UI port conflict before starting harness-mem-ui"
+    return 1
+  fi
+
+  log "Starting harness-mem-ui... (port=${UI_PORT})"
+  (
+    cd "$REPO_ROOT"
+    nohup env \
+      HARNESS_MEM_HOST="$HOST" \
+      HARNESS_MEM_PORT="$PORT" \
+      HARNESS_MEM_UI_PORT="$UI_PORT" \
+      HARNESS_MEM_UI_PARITY_V1="${HARNESS_MEM_UI_PARITY_V1:-true}" \
+      bun run "$UI_ENTRY" >> "$UI_LOG_FILE" 2>&1 &
+    echo $! > "$UI_PID_FILE"
+  )
+
+  local new_ui_pid
+  new_ui_pid="$(read_ui_pid_file)"
+  if [ -z "$new_ui_pid" ]; then
+    echo "[ERR] Failed to create UI pid file" >&2
+    return 1
+  fi
+
+  if wait_for_ui; then
+    log "harness-mem-ui started (pid=${new_ui_pid}, url=http://${HOST}:${UI_PORT})"
+    return 0
+  fi
+
+  warn "UI health check failed after start timeout"
+  if is_pid_running "$new_ui_pid"; then
+    kill -TERM "$new_ui_pid" >/dev/null 2>&1 || true
+    sleep 1
+    if is_pid_running "$new_ui_pid"; then
+      kill -KILL "$new_ui_pid" >/dev/null 2>&1 || true
+    fi
+  fi
+  rm -f "$UI_PID_FILE"
+  return 1
+}
+
+stop_ui() {
+  local ui_pid
+  ui_pid="$(read_ui_pid_file)"
+  if [ -z "$ui_pid" ]; then
+    ui_pid="$(discover_ui_pid_from_port || true)"
+  fi
+
+  if [ -z "$ui_pid" ]; then
+    rm -f "$UI_PID_FILE"
+    return 0
+  fi
+
+  if ! is_pid_running "$ui_pid"; then
+    rm -f "$UI_PID_FILE"
+    return 0
+  fi
+
+  log "Stopping harness-mem-ui (pid=${ui_pid})..."
+  kill -TERM "$ui_pid" >/dev/null 2>&1 || true
+
+  local waited=0
+  while is_pid_running "$ui_pid" && [ "$waited" -lt "$STOP_TIMEOUT_SEC" ]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if is_pid_running "$ui_pid"; then
+    warn "UI did not exit in ${STOP_TIMEOUT_SEC}s, sending SIGKILL"
+    kill -KILL "$ui_pid" >/dev/null 2>&1 || true
+    sleep 0.5
+  fi
+
+  rm -f "$UI_PID_FILE"
+  log "harness-mem-ui stopped"
+  return 0
+}
+
 start_daemon() {
   ensure_state_dir
   apply_log_rotation
@@ -416,13 +588,19 @@ start_daemon() {
     else
       log "harness-memd already running (health endpoint reachable)"
     fi
-    return 0
+    if start_ui; then
+      return 0
+    fi
+    return 1
   fi
 
   if [ -n "$pid" ] && is_pid_running "$pid"; then
     if is_health_reachable; then
       log "harness-memd already running (pid=${pid})"
-      return 0
+      if start_ui; then
+        return 0
+      fi
+      return 1
     fi
     if is_pid_listening_on_port "$pid"; then
       warn "Pid exists but health check failed. restarting stale daemon..."
@@ -442,7 +620,10 @@ start_daemon() {
     echo "$runtime_pid" > "$PID_FILE"
     if wait_for_health; then
       log "harness-memd already running (pid=${runtime_pid})"
-      return 0
+      if start_ui; then
+        return 0
+      fi
+      return 1
     fi
     warn "Daemon listener exists on port ${PORT} (pid=${runtime_pid}) but health endpoint is unreachable"
     warn "Refusing to spawn duplicate daemon. Check runtime with: scripts/harness-memd status"
@@ -493,7 +674,10 @@ start_daemon() {
 
   if wait_for_health; then
     log "harness-memd started (pid=${new_pid}, port=${PORT})"
-    return 0
+    if start_ui; then
+      return 0
+    fi
+    return 1
   fi
 
   warn "Health check failed after start timeout"
@@ -511,6 +695,8 @@ start_daemon() {
 
 stop_daemon() {
   ensure_state_dir
+
+  stop_ui || true
 
   local pid
   pid="$(read_pid_file)"
@@ -678,14 +864,27 @@ doctor_daemon() {
     ok=1
   fi
 
-  local ui_pid
-  ui_pid="$(read_ui_pid_file)"
-  if [ -n "$ui_pid" ] && is_pid_running "$ui_pid"; then
-    echo "[ok] ui pid file points to running process: $ui_pid (port=${UI_PORT})"
-  elif [ -n "$ui_pid" ]; then
-    echo "[warn] ui pid file is stale"
+  if is_ui_enabled; then
+    if is_ui_reachable; then
+      echo "[ok] ui endpoint reachable: http://${HOST}:${UI_PORT}"
+    else
+      echo "[warn] ui endpoint not reachable: http://${HOST}:${UI_PORT}"
+      ok=1
+    fi
+
+    local ui_pid
+    ui_pid="$(read_ui_pid_file)"
+    if [ -n "$ui_pid" ] && is_pid_running "$ui_pid"; then
+      echo "[ok] ui pid file points to running process: $ui_pid (port=${UI_PORT})"
+    elif [ -n "$ui_pid" ]; then
+      echo "[warn] ui pid file is stale"
+      ok=1
+    else
+      echo "[warn] ui pid not found"
+      ok=1
+    fi
   else
-    echo "[info] ui pid not found (ui may be stopped)"
+    echo "[info] ui startup disabled (HARNESS_MEM_ENABLE_UI=false)"
   fi
 
   return "$ok"

--- a/tests/harness-memd-guardrails.test.ts
+++ b/tests/harness-memd-guardrails.test.ts
@@ -12,20 +12,20 @@ function randomPort(base = 41000, span = 2000): number {
 }
 
 function makeEnv(tmpHome: string, daemonPort: number, uiPort?: number): NodeJS.ProcessEnv {
+  const resolvedUiPort = typeof uiPort === "number" ? uiPort : randomPort(45000, 1000);
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HARNESS_MEM_HOME: tmpHome,
     HARNESS_MEM_DB_PATH: join(tmpHome, "harness-mem.db"),
     HARNESS_MEM_HOST: "127.0.0.1",
     HARNESS_MEM_PORT: String(daemonPort),
+    HARNESS_MEM_UI_PORT: String(resolvedUiPort),
+    HARNESS_MEM_ENABLE_UI: "true",
     HARNESS_MEM_CODEX_PROJECT_ROOT: ROOT,
     HARNESS_MEM_ENABLE_OPENCODE_INGEST: "false",
     HARNESS_MEM_ENABLE_CURSOR_INGEST: "false",
     HARNESS_MEM_ENABLE_ANTIGRAVITY_INGEST: "false",
   };
-  if (typeof uiPort === "number") {
-    env.HARNESS_MEM_UI_PORT = String(uiPort);
-  }
   return env;
 }
 
@@ -157,6 +157,42 @@ describe("harness-memd guardrails", () => {
     } finally {
       uiProc.kill();
       await uiProc.exited;
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  test("start launches Mem UI and stop tears it down", async () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), "hmem-guard-ui-start-"));
+    const daemonPort = randomPort();
+    const uiPort = randomPort(46000, 1000);
+    const env = makeEnv(tmpHome, daemonPort, uiPort);
+
+    try {
+      const start = await runHarnessMemd(["start"], env);
+      expect(start.code).toBe(0);
+
+      await waitUntil(async () => {
+        try {
+          const response = await fetch(`http://127.0.0.1:${uiPort}/api/context`);
+          return response.ok;
+        } catch {
+          return false;
+        }
+      });
+
+      const stop = await runHarnessMemd(["stop"], env);
+      expect(stop.code).toBe(0);
+
+      await waitUntil(async () => {
+        try {
+          await fetch(`http://127.0.0.1:${uiPort}/api/context`);
+          return false;
+        } catch {
+          return true;
+        }
+      });
+    } finally {
+      await runHarnessMemd(["stop"], env);
       rmSync(tmpHome, { recursive: true, force: true });
     }
   });

--- a/tests/test-memory-daemon-zombie.sh
+++ b/tests/test-memory-daemon-zombie.sh
@@ -10,6 +10,7 @@ export HARNESS_MEM_HOME="$TMP_HOME"
 export HARNESS_MEM_DB_PATH="$TMP_HOME/harness-mem.db"
 export HARNESS_MEM_HOST="127.0.0.1"
 export HARNESS_MEM_PORT="37989"
+export HARNESS_MEM_UI_PORT="38989"
 
 cleanup() {
   "$ROOT/scripts/harness-memd" stop --quiet >/dev/null 2>&1 || true
@@ -20,8 +21,12 @@ trap cleanup EXIT
 for i in $(seq 1 "$LOOPS"); do
   "$ROOT/scripts/harness-memd" start --quiet
   "$ROOT/scripts/harness-memd" stop --quiet
-  if pgrep -f "memory-server/src/index.ts" >/dev/null 2>&1; then
-    echo "[FAIL] potential zombie detected at loop $i"
+  if lsof -nP -tiTCP:"$HARNESS_MEM_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "[FAIL] daemon port still listening after stop at loop $i"
+    exit 1
+  fi
+  if lsof -nP -tiTCP:"$HARNESS_MEM_UI_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "[FAIL] ui port still listening after stop at loop $i"
     exit 1
   fi
   if [ $((i % 10)) -eq 0 ]; then

--- a/tests/test-memory-daemon.sh
+++ b/tests/test-memory-daemon.sh
@@ -9,6 +9,7 @@ export HARNESS_MEM_HOME="$TMP_HOME"
 export HARNESS_MEM_DB_PATH="$TMP_HOME/harness-mem.db"
 export HARNESS_MEM_HOST="127.0.0.1"
 export HARNESS_MEM_PORT="37988"
+export HARNESS_MEM_UI_PORT="38988"
 export HARNESS_MEM_CODEX_PROJECT_ROOT="$ROOT"
 
 cleanup() {
@@ -23,6 +24,10 @@ echo "[memory-test] start daemon"
 echo "[memory-test] health"
 HEALTH="$($ROOT/scripts/harness-mem-client.sh health)"
 printf '%s' "$HEALTH" | jq -e '.ok == true' >/dev/null
+
+echo "[memory-test] ui context"
+UI_CONTEXT="$(curl -sS --max-time 3 "http://127.0.0.1:${HARNESS_MEM_UI_PORT}/api/context")"
+printf '%s' "$UI_CONTEXT" | jq -e '.ok == true' >/dev/null
 
 echo "[memory-test] record event"
 $ROOT/scripts/harness-mem-client.sh record-event '{"event":{"platform":"claude","project":"test","session_id":"s1","event_type":"user_prompt","payload":{"content":"hello memory"},"tags":["test"],"privacy_tags":[]}}' >/dev/null


### PR DESCRIPTION
## Summary\n- include Mem UI runtime files in npm package so setup can run UI without cloning repo\n- auto-start Mem UI from harness-memd start (default port 37901, disable via HARNESS_MEM_ENABLE_UI=false)\n- show UI URL after setup success\n- add guardrail tests for UI start/stop behavior and update daemon smoke scripts\n- bump package version to 0.1.17\n\n## Verification\n- bash -n scripts/harness-memd\n- bash -n scripts/harness-mem\n- bun test tests/harness-memd-guardrails.test.ts\n- bun test tests/doctor-json-contract.test.ts tests/readme-plans-rules.test.ts\n- bash tests/test-memory-daemon.sh\n- bash tests/test-memory-daemon-zombie.sh 5\n- npm pack --dry-run\n- setup dry run in isolated HOME confirmed API + UI reachable\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Mem UIがセットアップ時に自動起動し、http://127.0.0.1:37901でアクセス可能に。HARNESS_MEM_ENABLE_UIで制御可能。

* **Bug Fixes**
  * Mem UIの手動起動が不要に。ユーザー体験の向上。

* **Documentation**
  * セットアップガイド、変更履歴、READMEを更新。新機能と設定オプションを記載。

* **Chores**
  * バージョンを0.1.17にアップデート。Mem UIランタイムファイルをパッケージに統合。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->