### PR TITLE
fix: canonicalize project alias split (basename vs absolute path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,49 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.18] - 2026-02-22
+
+### What changed for users
+
+Project names in memory are now normalized to a single canonical value, so the same workspace no longer splits into separate entries like `harness-mem` and `/.../harness-mem`.
+
+### Added
+
+- Startup migration that rewrites legacy basename project rows to the canonical `codexProjectRoot` path for `mem_sessions`, `mem_events`, `mem_observations`, `mem_facts`, and `mem_consolidation_queue`.
+- Regression tests for basename-to-path canonicalization and legacy project alias migration.
+
+### Changed
+
+- Project normalization now resolves basename-style project values to the configured workspace root when names match.
+- API-side project filters (`search`, `feed`, `sessions`, `resume-pack`, and chain resolution) now use the same canonical project normalization path.
+
+### Fixed
+
+- Prevented feed/project sidebar fragmentation caused by mixed project identifiers (`basename` vs absolute path).
+- Prevented confusion between `session_id` UUID values and project buckets by keeping project namespaces consistent.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- No manual migration command is required. Existing legacy project aliases are normalized automatically on daemon startup.
+
+### Verification
+
+- `bun test memory-server/tests/unit/workspace-boundary.test.ts`
+- `bun test memory-server/tests/unit/core.test.ts`
+- `bun test` (cwd: `memory-server`)
+- `bun run --cwd memory-server typecheck`
+- `bun run --cwd harness-mem-ui typecheck`
+- `bun run --cwd harness-mem-ui test:ui`
+- `npm pack --dry-run`
+
 ## [0.1.17] - 2026-02-22
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,19 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.18] - 2026-02-22
+
+### ユーザー向け要約
+
+- 同じワークスペースが `harness-mem` と `/.../harness-mem` に分裂して表示される問題を修正。
+- `project` 名の正規化を統一し、同一プロジェクトのフィード/検索が1つの名前空間にまとまるよう改善。
+
+### 補足
+
+- 起動時に legacy データ（basename 側）を canonical path 側へ自動統一するマイグレーションを追加。
+- `search` / `feed` / `sessions` / `resume-pack` / `session chain` で同一の project 正規化を適用。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.17] - 2026-02-22
 
 ### ユーザー向け要約

--- a/Plans.md
+++ b/Plans.md
@@ -931,3 +931,18 @@ Optional:
 1. 4提出物JSON + 人間評価サマリが揃う
 2. 必須項目を満たす run が 3回連続で再現
 3. 失敗時に `原因/影響/次コマンド` を1画面で確認できる
+
+---
+
+## 17. project名分断修正 + 配信（2026-02-22）
+
+- [x] `cc:完了 [feature:tdd]` REL-001 `project` 正規化統一（`harness-mem` と絶対パスの分断解消）
+  - 依頼内容: `session_id`（UUID）と `project` の混同を防ぎ、`project` が basename/絶対パスで分断されないよう修正して配信まで完了する。
+  - 受入条件:
+    1. `project='harness-mem'` と `project='/.../harness-mem'` が自動統一される（少なくとも codexProjectRoot 対象）
+    2. 既存DBでも統一マイグレーションが動作する
+    3. 回帰テストが追加され、CI相当テストが通る
+    4. release tag 作成後、GitHub Release workflow が成功する
+  - 変更: `memory-server/src/core/harness-mem-core.ts`, `memory-server/tests/unit/workspace-boundary.test.ts`, `README.md`, `docs/harness-mem-setup.md`, `CHANGELOG.md`, `CHANGELOG_ja.md`, `package.json`
+  - 変更理由: basename と絶対パスの project 混在を canonical path に統一し、起動時に legacy alias を自動移行することでフィード/検索の分断を解消した。
+  - 検証: `bun test memory-server/tests/unit/workspace-boundary.test.ts`, `bun test memory-server/tests/unit/core.test.ts`, `bun test`(memory-server), `bun run --cwd memory-server typecheck`, `bun run --cwd harness-mem-ui typecheck`, `bun run --cwd harness-mem-ui test:ui`, `npm pack --dry-run`

--- a/README.md
+++ b/README.md
@@ -307,6 +307,14 @@ npx -y --package @chachamaru127/harness-mem harness-mem setup --platform codex,c
 harness-mem uninstall --purge-db
 ```
 
+### 6) Same workspace appears as both `harness-mem` and `/.../harness-mem`
+
+Restart daemon once to run automatic alias normalization (v0.1.18+):
+
+```bash
+harness-memd restart
+```
+
 ## FAQ
 
 ### Is this a hosted service?

--- a/docs/harness-mem-setup.md
+++ b/docs/harness-mem-setup.md
@@ -477,6 +477,7 @@ This will:
 | `Daemon doctor reported warnings` | daemon 停止中 | `harness-memd start` |
 | `Port <port> is already in use by another process` | 既存プロセスがポート占有 | 競合プロセス停止または `HARNESS_MEM_PORT` / `HARNESS_MEM_UI_PORT` を変更 |
 | `doctor_post_check` failed | セットアップ後の診断で不整合 | `harness-mem doctor --fix` |
+| 同じプロジェクトが `harness-mem` と `/.../harness-mem` に分かれる | 旧データが basename / 絶対パスで混在 | `harness-memd restart`（v0.1.18+ で起動時に自動統一） |
 
 ### doctor --fix を使った自動修復
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary
- Canonicalize project names so basename inputs that match `codexProjectRoot` are normalized to the canonical absolute path.
- Add startup migration to rewrite legacy basename project rows (`harness-mem`) into canonical path rows across session/event/observation/fact/consolidation tables.
- Normalize API-side project filters with the same canonicalization path.
- Add regression tests for canonicalization and startup migration.
- Bump package version to `0.1.18` and update changelogs/docs.

## Why
Users saw one workspace split across multiple project buckets (e.g. `harness-mem` and `/.../harness-mem`), which fragmented feed/search/results.

## Verification
- `bun test memory-server/tests/unit/workspace-boundary.test.ts`
- `bun test memory-server/tests/unit/core.test.ts`
- `bun test` (cwd: `memory-server`)
- `bun run --cwd memory-server typecheck`
- `bun run --cwd harness-mem-ui typecheck`
- `bun run --cwd harness-mem-ui test:ui`
- `npm pack --dry-run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート v0.1.19

* **Bug Fixes**
  * サイドバーの断片化やセッションIDとプロジェクトの命名不整合を解消

* **New Features**
  * プロジェクト名を1つの正準（canonical）パスに統一する自動正規化を導入
  * デーモン起動時にレガシー別名を自動で統一するマイグレーションを追加

* **Tests**
  * 正規化および起動時マイグレーションの回帰テストを追加

* **Documentation**
  * トラブルシューティングと導入手順に正規化挙動を追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->