### PR TITLE
fix: bootstrap MCP dist for git-based installs

### DIFF
--- a/scripts/harness-mem
+++ b/scripts/harness-mem
@@ -988,10 +988,21 @@ PY
 ensure_mcp_runtime() {
   local mcp_dir="${HARNESS_ROOT}/mcp-server"
   local mcp_dist="${mcp_dir}/dist/index.js"
+  local mcp_src_entry="${mcp_dir}/src/index.ts"
   local mcp_sdk_local="${mcp_dir}/node_modules/@modelcontextprotocol/sdk/package.json"
   local mcp_sdk_root="${HARNESS_ROOT}/node_modules/@modelcontextprotocol/sdk/package.json"
 
-  [ -f "$mcp_dist" ] || fail "MCP dist entry missing: $mcp_dist"
+  if [ ! -f "$mcp_dist" ]; then
+    [ -f "$mcp_src_entry" ] || fail "MCP dist entry missing and source unavailable: $mcp_dist"
+    log "MCP dist entry missing. Bootstrapping local MCP build."
+    (
+      cd "$mcp_dir"
+      npm install --silent --include=dev
+      npm run build --silent
+    )
+  fi
+
+  [ -f "$mcp_dist" ] || fail "MCP dist build failed: $mcp_dist"
 
   if [ -f "$mcp_sdk_local" ] || [ -f "$mcp_sdk_root" ]; then
     return
@@ -2387,7 +2398,7 @@ setup_impl() {
     _setup_record "mcp_runtime" "ok" ""
   else
     ensure_mcp_runtime
-    _setup_record "mcp_runtime" "failed" "cd ${HARNESS_ROOT}/mcp-server && npm install"
+    _setup_record "mcp_runtime" "failed" "cd ${HARNESS_ROOT}/mcp-server && npm install --include=dev && npm run build"
     _setup_print_repair_suggestions "${SETUP_RESULTS[@]}"
     return 1
   fi

--- a/tests/mcp-runtime-bootstrap-contract.test.ts
+++ b/tests/mcp-runtime-bootstrap-contract.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("MCP runtime bootstrap contract", () => {
+  test("ensure_mcp_runtime bootstraps dist when missing", () => {
+    const script = readFileSync(join(process.cwd(), "scripts/harness-mem"), "utf8");
+
+    expect(script).toContain("ensure_mcp_runtime()");
+    expect(script).toContain("MCP dist entry missing. Bootstrapping local MCP build.");
+    expect(script).toContain("npm install --silent --include=dev");
+    expect(script).toContain("npm run build --silent");
+    expect(script).toContain("MCP dist build failed:");
+  });
+});


### PR DESCRIPTION
## Summary
- restore MCP runtime bootstrap fallback when `mcp-server/dist/index.js` is missing
- build MCP dist automatically with `npm install --include=dev && npm run build`
- improve setup repair hint for `mcp_runtime` failures
- add contract test to prevent regression

## Why
Git-based installs can miss `mcp-server/dist` because `dist` is not tracked in Git. Without fallback build, `harness-mem doctor` fails immediately with `MCP dist entry missing`.

## Validation
- bun test tests/mcp-runtime-bootstrap-contract.test.ts
- bun test tests/doctor-json-contract.test.ts tests/harness-memd-guardrails.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * MCP環境の自動ブートストラップ機能を追加しました。必要なビルド済みファイルが存在しない場合、システムが自動的に依存関係をインストールしてビルドを実行するようになりました。

* **テスト**
  * ブートストラップ処理の動作を検証するテストを新たに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->