### PR TITLE
chore: release v0.1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,42 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.27] - 2026-02-24
+
+### What changed for users
+
+- Release automation is now resilient when a release tag is pushed shortly before the release branch merge reaches `main`.
+
+### Added
+
+- None.
+
+### Changed
+
+- `Release` workflow now retries main-containment verification for up to 15 minutes (`15s` interval).
+- Main-containment verification now uses a non-shallow `git fetch origin main` to avoid shallow-history false negatives.
+
+### Fixed
+
+- Fixed repeated `publish-npm` failures at `Verify tag commit is on main` that could occur with merge commits under `--depth=1` fetch.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- No migration is required.
+
+### Verification
+
+- Confirmed recurring failure signature in previous release runs (`v0.1.25`, `v0.1.26`) at `Verify tag commit is on main`.
+- Merged workflow fix in PR `#18` and released this patch version to apply the corrected guard in future releases.
+
 ## [0.1.26] - 2026-02-23
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,20 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.27] - 2026-02-24
+
+### ユーザー向け要約
+
+- タグ push と main 反映タイミングのズレで `publish-npm` が誤検知で失敗する問題を修正。
+- リリース時の main 含有チェックを待機リトライ化し、浅い fetch 起因の偽陰性を回避。
+
+### 補足
+
+- `Release` ワークフローの `Verify tag commit is on main` を改善（最大15分待機、15秒間隔）。
+- `git fetch origin main --depth=1` を廃止し、非 shallow fetch で祖先判定を実施。
+- 過去の失敗パターン（`v0.1.25`, `v0.1.26`）の再発防止が目的。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.26] - 2026-02-23
 
 ### ユーザー向け要約

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to 0.1.27
- include changelog entries for release workflow publish fix

## Notes
- addresses recurring publish failure at Verify tag commit is on main
- fix landed via #18, this release carries the corrected pipeline behavior forward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バージョン 0.1.27

* **バグ修正**
  * リリースタグ検証時の npm パブリッシュの繰り返しエラーを修正

* **改善**
  * リリースオートメーションの耐性が向上
  * メインブランチ検証の自動再試行機能を追加（最大 15 分、15 秒間隔）
  * Git フェッチ戦略の改善で誤検知を削減

<!-- end of auto-generated comment: release notes by coderabbit.ai -->