### PR TITLE
chore: release v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,45 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.28] - 2026-02-24
+
+### What changed for users
+
+- Release publishing is no longer blocked by false-negative test failures in the memory-server quality gate.
+- Claude feed visibility in the UI is more reliable when platform labels or project aliases vary.
+
+### Added
+
+- Added UI regression tests for Claude feed platform filtering and live-feed alias project matching.
+
+### Changed
+
+- Medium search-latency benchmark now uses a CI-aware budget (`1500ms` on CI, `500ms` locally) with reduced synthetic corpus load.
+- Antigravity ingest integration tests now assert against the normalized project key behavior.
+
+### Fixed
+
+- Fixed `managed-mode-wiring` test path resolution so it works when CI runs from `memory-server/`.
+- Fixed feed filtering to match `claude-*` platform labels when `platformFilter=claude`.
+- Fixed live feed prepend drops caused by strict string mismatch between selected project and normalized alias project paths.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- None.
+
+### Verification
+
+- `cd memory-server && bun test && bun run typecheck`
+- `cd harness-mem-ui && bun run test:ui && bun run typecheck`
+
 ## [0.1.27] - 2026-02-24
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,21 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.28] - 2026-02-24
+
+### ユーザー向け要約
+
+- `publish-npm` を止めていた memory-server 品質ゲートの誤失敗を修正し、再配信を安定化。
+- UI の Claude フィードで、`claude-*` 表記や project alias 差分による取りこぼしを防止。
+
+### 補足
+
+- `managed-mode-wiring` 統合テストの参照パスを `cwd` 非依存に修正（`cd memory-server` 実行でも成功）。
+- Antigravity 取込テストの期待 project を、現行の正規化キー仕様へ更新。
+- 中規模検索レイテンシテストは CI 環境向けに現実的な閾値と負荷へ調整（CI: 1500ms / local: 500ms）。
+- `useFeedPagination` に回帰テストを追加（`platformFilter=claude` と live feed の alias project）。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.27] - 2026-02-24
 
 ### ユーザー向け要約

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to `0.1.28`
- document release fixes for publish gate stabilization and Claude feed filtering in `CHANGELOG.md` / `CHANGELOG_ja.md`

## Included fixes
- CI release gate regressions fixed in #20 (memory-server tests + Claude feed filter resilience)

## Validation
- Existing fix branch validation from #20:
  - `cd memory-server && bun test && bun run typecheck`
  - `cd harness-mem-ui && bun run test:ui && bun run typecheck`
