### PR TITLE
chore: release v0.1.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,49 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.29] - 2026-02-24
+
+### What changed for users
+
+- Duplicate project entries are now auto-collapsed more aggressively (short name vs absolute path, and case-only variants).
+- Project filters and counts are more stable because project keys converge to canonical roots.
+
+### Added
+
+- Added workspace-boundary tests for:
+  - runtime canonicalization using observed absolute project roots
+  - startup migration from short legacy keys to unique observed absolute roots
+  - startup collapse of case-only short-name variants
+
+### Changed
+
+- Project alias migration now uses observed absolute project roots as canonical targets when basename match is unique.
+- Runtime project normalization now learns absolute project roots seen in incoming events and reuses them for subsequent basename-only events.
+
+### Fixed
+
+- Fixed split project lists such as `claude-code-harness` vs `/Users/.../claude-code-harness`.
+- Fixed split project lists such as `kage-bunshin` vs `/Users/.../kage-bunshin`.
+- Fixed case-only project key drift such as `Jarvis` vs `JARVIS`.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- Existing databases are normalized automatically at startup.
+- For immediate effect in long-running environments, restart `harness-memd` once.
+
+### Verification
+
+- `cd memory-server && bun test tests/unit/workspace-boundary.test.ts`
+- `cd memory-server && bun test && bun run typecheck`
+
 ## [0.1.28] - 2026-02-24
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,20 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.29] - 2026-02-24
+
+### ユーザー向け要約
+
+- `プロジェクト短名` と `絶対パス` の二重表示（例: `claude-code-harness` と `/Users/.../claude-code-harness`）を自動統合。
+- 大文字小文字だけ異なる project key（例: `Jarvis` / `JARVIS`）も起動時に統合。
+
+### 補足
+
+- 起動時の legacy alias 正規化を拡張し、既存DBから観測できる絶対パスを canonical key として優先採用。
+- 実行中も、絶対パスの project を観測した時点で正規化候補として学習し、以降の basename-only イベントを同一キーへ寄せる。
+- 既存環境では `harness-memd` 再起動で反映。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.28] - 2026-02-24
 
 ### ユーザー向け要約

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to `0.1.29`
- add release notes for project-key canonicalization improvements (short/absolute/case-only)
- include migration note: restart daemon to apply startup normalization immediately

## Included fixes
- project alias normalization from observed absolute roots (#22)

## Validation
- `cd memory-server && bun test tests/unit/workspace-boundary.test.ts`
- `cd memory-server && bun test`
- `cd memory-server && bun run typecheck`
