### PR TITLE
chore: release v0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,41 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.30] - 2026-02-24
+
+### What changed for users
+
+- System/tool envelope prompts are no longer shown as normal user prompts in Feed cards.
+
+### Added
+
+- Added a UI unit test that verifies system-envelope `user_prompt` cards are categorized as `other`.
+
+### Changed
+
+- Feed categorization now checks known system-envelope prefixes (e.g. `# AGENTS.md instructions`, `<environment_context>`) before classifying `user_prompt` cards as `prompt`.
+
+### Fixed
+
+- Fixed noisy prompt labeling where setup/instruction envelopes were misclassified as user prompts.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- No migration is required.
+
+### Verification
+
+- `bun run --cwd harness-mem-ui test:ui tests/ui/feed-panel.test.tsx`
+- `bun run --cwd harness-mem-ui typecheck`
+
 ## [0.1.29] - 2026-02-24
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,18 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.30] - 2026-02-24
+
+### ユーザー向け要約
+
+- Feed で、`# AGENTS.md instructions` や `<environment_context>` などのシステム包み込み入力を通常のユーザープロンプトとして表示しないよう修正。
+
+### 補足
+
+- `user_prompt` 判定の前にシステム包み込みプレフィックスを判定し、該当カードは `other` として分類。
+- 回帰防止として `harness-mem-ui/tests/ui/feed-panel.test.tsx` に専用テストを追加。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.29] - 2026-02-24
 
 ### ユーザー向け要約

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to `0.1.30`
- add changelog entries for system-envelope prompt categorization fix

## Verification
- `bun run --cwd harness-mem-ui test:ui tests/ui/feed-panel.test.tsx`
- `bun run --cwd harness-mem-ui typecheck`
