### PR TITLE
fix(cli): prompt update opt-in only when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ harness-mem setup --platform codex,cursor,claude
 harness-mem update
 ```
 
-`harness-mem update` prompts for auto-update opt-in: "Enable opt-in automatic updates for harness-mem?", then updates the global package.
+`harness-mem update` prompts for auto-update opt-in only when auto-update is currently disabled, then updates the global package.
 You can still update manually with `npm install -g @chachamaru127/harness-mem@latest`.
 
 ### Verify setup
@@ -74,7 +74,7 @@ The tab is read-only in V1 and masks sensitive values before rendering.
 | `setup` | Configure tool wiring and start daemon + Mem UI |
 | `doctor` | Validate wiring/health and optionally repair with `--fix` |
 | `versions` | Snapshot local vs upstream tool versions |
-| `update` | Update global package and prompt auto-update opt-in |
+| `update` | Update global package; prompt auto-update opt-in only if currently disabled |
 | `smoke` | Run isolated privacy/search sanity checks |
 | `uninstall` | Remove wiring and optional local DB (`--purge-db`) |
 | `import-claude-mem` + `verify-import` + `cutover-claude-mem` | Safe migration from Claude-mem |

--- a/README_ja.md
+++ b/README_ja.md
@@ -33,7 +33,7 @@ harness-mem setup --platform codex,cursor,claude
 harness-mem update
 ```
 
-`harness-mem update` 実行時に「harness-mem の自動更新（opt-in）を有効化しますか?」の確認が表示され、選択後にグローバル更新を実行します。
+`harness-mem update` 実行時は、自動更新が無効な場合のみ「harness-mem の自動更新（opt-in）を有効化しますか?」の確認が表示され、選択後にグローバル更新を実行します。
 従来どおり `npm install -g @chachamaru127/harness-mem@latest` で手動更新も可能です。
 
 ### セットアップ確認
@@ -67,7 +67,7 @@ V1 は read-only（閲覧専用）で、機密値は表示前にマスクされ�
 | `setup` | ツール配線を自動設定し、daemon + Mem UI を起動 |
 | `doctor` | 配線/稼働状態を検査し、`--fix` で修復 |
 | `versions` | 各ツールの local / upstream バージョン差分を記録 |
-| `update` | グローバル更新を実行し、自動更新の opt-in を確認 |
+| `update` | グローバル更新を実行（自動更新が無効な場合のみ opt-in を確認） |
 | `smoke` | プライバシーと検索品質の最小 E2E 検証 |
 | `uninstall` | 配線解除と必要時の DB 削除（`--purge-db`） |
 | `import-claude-mem` + `verify-import` + `cutover-claude-mem` | Claude-mem からの安全移行 |

--- a/docs/harness-mem-setup.md
+++ b/docs/harness-mem-setup.md
@@ -24,7 +24,7 @@ harness-mem setup
 harness-mem update
 ```
 
-`harness-mem update` asks whether to enable auto-update opt-in, then runs:
+`harness-mem update` asks whether to enable auto-update opt-in only when auto-update is currently disabled, then runs:
 
 ```bash
 npm install -g @chachamaru127/harness-mem@latest
@@ -104,7 +104,7 @@ Options:
 
 ### `update`
 
-Update the global package and set auto-update opt-in interactively.
+Update the global package and set auto-update opt-in when currently disabled.
 
 ```bash
 harness-mem update
@@ -112,7 +112,7 @@ harness-mem update
 
 Notes:
 
-- On interactive TTY, it prompts: `Enable opt-in automatic updates for harness-mem?` (`y/N`).
+- On interactive TTY, it prompts `Enable opt-in automatic updates for harness-mem?` (`y/N`) only when auto-update is currently disabled.
 - The selected value is stored in `~/.harness-mem/config.json` (`auto_update.enabled`).
 
 ### `versions`

--- a/scripts/harness-mem
+++ b/scripts/harness-mem
@@ -574,7 +574,13 @@ should_prompt_update_auto_update_selection() {
   if [ "${HARNESS_MEM_NON_INTERACTIVE:-0}" = "1" ]; then
     return 1
   fi
-  if [ -t 0 ] || [ "${HARNESS_MEM_FORCE_UPDATE_PROMPT:-0}" = "1" ]; then
+  if [ "${HARNESS_MEM_FORCE_UPDATE_PROMPT:-0}" = "1" ]; then
+    return 0
+  fi
+  if [ "$(read_auto_update_enabled)" -eq 1 ]; then
+    return 1
+  fi
+  if [ -t 0 ]; then
     return 0
   fi
   return 1

--- a/tests/update-command-contract.test.ts
+++ b/tests/update-command-contract.test.ts
@@ -3,12 +3,13 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("update command contract", () => {
-  test("harness-mem script exposes interactive update command with auto-update opt-in prompt", () => {
+  test("harness-mem script exposes update command and prompts only when auto-update is disabled", () => {
     const script = readFileSync(join(process.cwd(), "scripts/harness-mem"), "utf8");
 
     expect(script).toContain("update     Update global harness-mem package");
     expect(script).toContain("should_prompt_update_auto_update_selection()");
     expect(script).toContain("prompt_update_auto_update_selection()");
+    expect(script).toContain("if [ \"$(read_auto_update_enabled)\" -eq 1 ]; then");
     expect(script).toContain("update_impl()");
     expect(script).toContain("npm install -g \"${AUTO_UPDATE_PACKAGE}@${AUTO_UPDATE_CHANNEL}\"");
   });


### PR DESCRIPTION
## Summary
- change `harness-mem update` prompt behavior to ask auto-update opt-in only when currently disabled
- keep prompt bypass for non-interactive mode
- keep explicit override via `HARNESS_MEM_FORCE_UPDATE_PROMPT=1`
- update README/README_ja/setup guide wording to match behavior
- tighten update command contract test

## Verification
- `bash -n scripts/harness-mem`
- `bun test tests/update-command-contract.test.ts`
