### PR TITLE
chore: release v0.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,43 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - None.
 
+## [0.1.32] - 2026-02-24
+
+### What changed for users
+
+- `harness-mem update` now asks the auto-update opt-in question only when auto-update is currently disabled.
+
+### Added
+
+- None.
+
+### Changed
+
+- Update-time prompt gate now checks existing `auto_update.enabled` state before asking.
+- Documentation wording for `harness-mem update` now matches the gated prompt behavior.
+
+### Fixed
+
+- Fixed repeated opt-in prompts for users who had already enabled auto-update.
+
+### Removed
+
+- None.
+
+### Security
+
+- None.
+
+### Migration Notes
+
+- No migration is required.
+- For users with auto-update already enabled, `harness-mem update` proceeds without asking the opt-in question.
+
+### Verification
+
+- `bash -n scripts/harness-mem`
+- `bun test tests/update-command-contract.test.ts`
+
 ## [0.1.31] - 2026-02-24
 
 ### What changed for users

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,18 @@
 - 公式の変更履歴（Source of Truth）: [CHANGELOG.md](./CHANGELOG.md)
 - 最新のリリース内容と移行手順は英語版を参照してください。
 
+## [0.1.32] - 2026-02-24
+
+### ユーザー向け要約
+
+- `harness-mem update` の確認ダイアログを改善し、自動更新が無効なユーザーにだけ opt-in 質問を表示するよう修正。
+
+### 補足
+
+- 自動更新がすでに有効なユーザーは、`harness-mem update` 実行時に毎回質問されずそのまま更新処理へ進む。
+- README / README_ja / setup guide の説明文を実装仕様に合わせて更新。
+- 詳細は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
+
 ## [0.1.31] - 2026-02-24
 
 ### ユーザー向け要約

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Unified memory runtime setup CLI for Claude Code, Codex, OpenCode, and Cursor",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to `0.1.32`
- add changelog entries for update prompt gating behavior

## Verification
- `bash -n scripts/harness-mem`
- `bun test tests/update-command-contract.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.1.32

* **修正**
  * 自動更新が既に有効なユーザーに対する重複したオプトインプロンプト表示を防止

* **改善**
  * harness-mem 更新時のオプトイン確認ダイアログを改善。自動更新が無効な場合のみプロンプトを表示し、有効なユーザーは確認画面をスキップして更新を実行

<!-- end of auto-generated comment: release notes by coderabbit.ai -->