### PR TITLE
fix: support Windows Codex via Git Bash launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "license": "BUSL-1.1",
   "type": "commonjs",
   "bin": {
-    "harness-mem": "scripts/harness-mem",
-    "harness-memd": "scripts/harness-memd",
-    "harness-mem-client": "scripts/harness-mem-client.sh"
+    "harness-mem": "scripts/harness-mem.js",
+    "harness-memd": "scripts/harness-memd.js",
+    "harness-mem-client": "scripts/harness-mem-client.js"
   },
   "files": [
     "README.md",

--- a/scripts/harness-mem-client.js
+++ b/scripts/harness-mem-client.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { runBashEntry } = require("./lib/bash-entry");
+
+process.exit(
+  runBashEntry({
+    commandName: "harness-mem-client",
+    scriptRelativePath: "harness-mem-client.sh",
+  })
+);

--- a/scripts/harness-mem.js
+++ b/scripts/harness-mem.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { runBashEntry } = require("./lib/bash-entry");
+
+process.exit(
+  runBashEntry({
+    commandName: "harness-mem",
+    scriptRelativePath: "harness-mem",
+  })
+);

--- a/scripts/harness-memd.js
+++ b/scripts/harness-memd.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { runBashEntry } = require("./lib/bash-entry");
+
+process.exit(
+  runBashEntry({
+    commandName: "harness-memd",
+    scriptRelativePath: "harness-memd",
+  })
+);

--- a/scripts/lib/bash-entry.js
+++ b/scripts/lib/bash-entry.js
@@ -1,0 +1,165 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const WINDOWS_PATH_FLAGS = new Set(["--project", "--source", "--dest-dir"]);
+
+function effectivePlatform(env = process.env) {
+  return env.HARNESS_MEM_FORCE_PLATFORM || process.platform;
+}
+
+function windowsUnsupportedMessage(commandName) {
+  return [
+    `[harness-mem][error] \`${commandName}\` requires bash, which was not found on this system.`,
+    "Reason: the current setup and hook wiring depend on POSIX shell scripts.",
+    "",
+    "Recommended solutions:",
+    "  1. Install Git for Windows (https://gitforwindows.org/) — it includes Git Bash",
+    "  2. Run harness-mem from Git Bash terminal",
+    "  3. Use WSL2 (e.g. Ubuntu) and run the same command there",
+    "",
+    "If Git Bash is already installed, ensure 'bash' is available in your PATH.",
+  ].join("\n");
+}
+
+function isWindowsAbsolutePath(value) {
+  return typeof value === "string" && /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function toPosixWindowsPath(value) {
+  if (!isWindowsAbsolutePath(value)) {
+    return value;
+  }
+
+  const driveLetter = value[0].toLowerCase();
+  const remainder = value.slice(2).replace(/\\/g, "/");
+  return `/${driveLetter}${remainder.startsWith("/") ? remainder : `/${remainder}`}`;
+}
+
+function normalizeWindowsCliArg(arg) {
+  return isWindowsAbsolutePath(arg) ? toPosixWindowsPath(arg) : arg;
+}
+
+function normalizeWindowsCliArgs(args) {
+  const normalized = [];
+  let expectsPathValue = false;
+
+  for (const arg of args) {
+    if (expectsPathValue) {
+      normalized.push(normalizeWindowsCliArg(arg));
+      expectsPathValue = false;
+      continue;
+    }
+
+    const matchedFlag = [...WINDOWS_PATH_FLAGS].find((flag) => arg.startsWith(`${flag}=`));
+    if (matchedFlag) {
+      const value = arg.slice(matchedFlag.length + 1);
+      normalized.push(`${matchedFlag}=${normalizeWindowsCliArg(value)}`);
+      continue;
+    }
+
+    normalized.push(arg);
+    expectsPathValue = WINDOWS_PATH_FLAGS.has(arg);
+  }
+
+  return normalized;
+}
+
+function readSpawnOutput(result) {
+  return [result.stdout, result.stderr]
+    .filter(Boolean)
+    .map((chunk) => chunk.toString())
+    .join("\n");
+}
+
+function looksLikeWindowsGitBash(versionOutput) {
+  return /(msys|mingw|cygwin|git for windows)/i.test(versionOutput);
+}
+
+/**
+ * Find a usable bash binary on Windows.
+ * Returns the path to bash.exe if found, or null if not available.
+ */
+function findWindowsBash({
+  env = process.env,
+  spawnImpl = spawnSync,
+  existsSyncImpl = fs.existsSync,
+} = {}) {
+  // Search well-known Git Bash / MSYS2 locations
+  const candidates = [
+    "C:\\Program Files\\Git\\bin\\bash.exe",
+    "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+    `${env.PROGRAMFILES || ""}\\Git\\bin\\bash.exe`,
+    `${env["PROGRAMFILES(X86)"] || ""}\\Git\\bin\\bash.exe`,
+    "C:\\msys64\\usr\\bin\\bash.exe",
+    "C:\\msys32\\usr\\bin\\bash.exe",
+  ];
+
+  for (const candidate of [...new Set(candidates)].filter(Boolean)) {
+    if (existsSyncImpl(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Fall back to bash on PATH only when it looks like Git Bash / MSYS2.
+  const pathCheck = spawnImpl("bash", ["--version"], {
+    stdio: "pipe",
+    timeout: 5000,
+    env,
+  });
+  if (!pathCheck.error && pathCheck.status === 0 && looksLikeWindowsGitBash(readSpawnOutput(pathCheck))) {
+    return "bash";
+  }
+
+  return null;
+}
+
+function runBashEntry({ commandName, scriptRelativePath, args = process.argv.slice(2), env = process.env, cwd = process.cwd() }) {
+  const platform = effectivePlatform(env);
+  let bashPath = "bash";
+
+  if (platform === "win32") {
+    const found = findWindowsBash();
+    if (!found) {
+      console.error(windowsUnsupportedMessage(commandName));
+      return 1;
+    }
+    bashPath = found;
+    // Note: do NOT set MSYS_NO_PATHCONV here — the harness-mem scripts call
+    // Windows-native binaries (jq, curl, etc.) that rely on MSYS automatic
+    // path conversion from /c/Users/... to C:\Users\...
+  }
+
+  const scriptPath = path.resolve(__dirname, "..", scriptRelativePath);
+  const normalizedScriptPath = platform === "win32" ? toPosixWindowsPath(scriptPath) : scriptPath;
+  const normalizedArgs = platform === "win32" ? normalizeWindowsCliArgs(args) : args;
+
+  const result = spawnSync(bashPath, [normalizedScriptPath, ...normalizedArgs], {
+    stdio: "inherit",
+    env,
+    cwd,
+  });
+
+  if (result.error) {
+    console.error(`[harness-mem][error] Failed to start bash for \`${commandName}\`: ${result.error.message}`);
+    return 1;
+  }
+
+  if (typeof result.status === "number") {
+    return result.status;
+  }
+
+  return 1;
+}
+
+module.exports = {
+  effectivePlatform,
+  findWindowsBash,
+  isWindowsAbsolutePath,
+  looksLikeWindowsGitBash,
+  normalizeWindowsCliArg,
+  normalizeWindowsCliArgs,
+  toPosixWindowsPath,
+  runBashEntry,
+  windowsUnsupportedMessage,
+};

--- a/tests/windows-cli-entry-contract.test.ts
+++ b/tests/windows-cli-entry-contract.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const PACKAGE_JSON = resolve(ROOT, "package.json");
+const require = createRequire(import.meta.url);
+const bashEntry = require(resolve(ROOT, "scripts/lib/bash-entry.js")) as {
+  findWindowsBash: (options?: {
+    env?: NodeJS.ProcessEnv;
+    spawnImpl?: (command: string, args: string[], options: Record<string, unknown>) => {
+      error?: unknown;
+      status?: number | null;
+      stdout?: Buffer | string;
+      stderr?: Buffer | string;
+    };
+    existsSyncImpl?: (path: string) => boolean;
+  }) => string | null;
+  looksLikeWindowsGitBash: (versionOutput: string) => boolean;
+  normalizeWindowsCliArgs: (args: string[]) => string[];
+  toPosixWindowsPath: (value: string) => string;
+  windowsUnsupportedMessage: (commandName: string) => string;
+};
+
+describe("windows CLI entry contract", () => {
+  test("package bin entries point at node launchers instead of raw bash scripts", () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+      bin: Record<string, string>;
+    };
+
+    expect(pkg.bin["harness-mem"]).toBe("scripts/harness-mem.js");
+    expect(pkg.bin["harness-memd"]).toBe("scripts/harness-memd.js");
+    expect(pkg.bin["harness-mem-client"]).toBe("scripts/harness-mem-client.js");
+  });
+
+  test("Windows script paths are normalized to Git Bash POSIX paths", () => {
+    expect(bashEntry.toPosixWindowsPath("C:\\Users\\shuta\\repo\\scripts\\harness-mem")).toBe(
+      "/c/Users/shuta/repo/scripts/harness-mem"
+    );
+    expect(bashEntry.toPosixWindowsPath("D:\\worktree\\tmp\\data.db")).toBe("/d/worktree/tmp/data.db");
+  });
+
+  test("Windows CLI path flags are normalized before invoking Git Bash", () => {
+    expect(
+      bashEntry.normalizeWindowsCliArgs([
+        "setup",
+        "--platform",
+        "codex",
+        "--project",
+        "C:\\Users\\shuta\\OneDrive\\Desktop\\Code\\harness-mem",
+        "--source=C:\\tmp\\claude-mem.db",
+        "--dest-dir",
+        "D:\\backups\\harness-mem",
+      ])
+    ).toEqual([
+      "setup",
+      "--platform",
+      "codex",
+      "--project",
+      "/c/Users/shuta/OneDrive/Desktop/Code/harness-mem",
+      "--source=/c/tmp/claude-mem.db",
+      "--dest-dir",
+      "/d/backups/harness-mem",
+    ]);
+  });
+
+  test("Git Bash detection ignores non-MSYS bash and prefers Git for Windows candidates", () => {
+    const seen: string[] = [];
+    const bashPath = bashEntry.findWindowsBash({
+      env: {
+        ...process.env,
+        PROGRAMFILES: "C:\\Program Files",
+        "PROGRAMFILES(X86)": "C:\\Program Files (x86)",
+      },
+      spawnImpl: (command: string) => {
+        seen.push(command);
+        return {
+          status: 0,
+          stdout: Buffer.from("GNU bash, version 5.2.21(1)-release (x86_64-pc-linux-gnu)\n"),
+          stderr: Buffer.alloc(0),
+        };
+      },
+      existsSyncImpl: (candidate: string) => candidate === "C:\\Program Files\\Git\\bin\\bash.exe",
+    });
+
+    expect(seen).toEqual([]);
+    expect(bashPath).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+  });
+
+  test("PATH bash is accepted when it looks like Git Bash / MSYS2", () => {
+    const bashPath = bashEntry.findWindowsBash({
+      env: {
+        ...process.env,
+        PROGRAMFILES: "",
+        "PROGRAMFILES(X86)": "",
+      },
+      spawnImpl: () => ({
+        status: 0,
+        stdout: Buffer.from("GNU bash, version 5.2.15(1)-release (x86_64-pc-msys)\n"),
+        stderr: Buffer.alloc(0),
+      }),
+      existsSyncImpl: () => false,
+    });
+
+    expect(bashPath).toBe("bash");
+    expect(bashEntry.looksLikeWindowsGitBash("GNU bash, version 5.2.15(1)-release (x86_64-pc-msys)")).toBe(true);
+    expect(bashEntry.looksLikeWindowsGitBash("GNU bash, version 5.2.21(1)-release (x86_64-pc-linux-gnu)")).toBe(
+      false
+    );
+  });
+
+  test("missing Git Bash still returns an actionable Windows error message", () => {
+    const stderr = bashEntry.windowsUnsupportedMessage("harness-mem");
+    expect(stderr).toContain("Install Git for Windows");
+    expect(stderr).toContain("Run harness-mem from Git Bash terminal");
+    expect(stderr).toContain("Use WSL2");
+  });
+});


### PR DESCRIPTION
## Summary
- switch the published npm bin entries to Node launchers on Windows
- add a shared `bash-entry` helper that finds Git Bash on Windows and normalizes `C:\...` paths to Git Bash POSIX paths before invoking the POSIX setup scripts
- add a Windows CLI contract test for launcher wiring, path normalization, Git Bash detection, and actionable fail-fast messaging

## Scope
This PR targets the Windows Codex launcher issue only.
It assumes Git for Windows is installed and makes native PowerShell / CMD launch the existing POSIX setup scripts through Git Bash.

## Validation
- `C:\Users\shuta\.bun\bin\bun.exe test tests\windows-cli-entry-contract.test.ts`
- native Windows failure reproduced before the fix with `/bin/bash: C:...\scripts\harness-mem: No such file or directory`

## Notes
- existing bash scripts remain the source of truth for setup / doctor logic
- if Git Bash is unavailable, the launcher now fails with explicit installation guidance instead of an opaque `/bin/bash.exe` style error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CLIコマンドの実行システムを更新し、Windows環境でのサポートを強化しました。

* **Tests**
  * Windows CLI実行契約の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->