### PR TITLE
fix: align marketplace metadata version with v0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode, Gemini CLI)",
-  "version": "0.9.0",
+  "version": "0.10.0",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"


### PR DESCRIPTION
## Summary
- Update `.claude-plugin/marketplace.json` version from `0.9.0` to `0.10.0`
- Align marketplace metadata with the current released plugin version

## Notes
- Limited to 1 file
- No implementation changes

## Test plan
- [x] `bun test tests/marketplace-schema.test.ts` — 22 pass / 0 fail
- [x] Full suite: 1908 pass / 60 fail / 14 skip → 1909 pass / 59 fail / 14 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース バージョン 0.10.0

* **その他**
  * プラグインメタデータのバージョンを 0.10.0 にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->