### PR TITLE
fix: align doctor --json all_green with failed_count (CI blocker for v0.11.0)

### DIFF
--- a/scripts/harness-mem
+++ b/scripts/harness-mem
@@ -3403,6 +3403,12 @@ doctor_impl() {
   fi
 
   # Go MCP binary check
+  #
+  # Status semantics must match _doctor_emit_json's "ok" / "ok:*" contract
+  # so that failed_count and all_green stay consistent. Go binary absence
+  # is an acceptable state (the wrapper script falls back to Node.js), so
+  # it is reported with an "ok:*" prefix. A broken-but-present binary is
+  # a real failure and flips the failed flag.
   local go_bin_name go_bin_path
   go_bin_name="$(_resolve_go_bin_name)"
   go_bin_path="${HARNESS_ROOT}/bin/${go_bin_name}"
@@ -3415,9 +3421,10 @@ doctor_impl() {
     else
       _doctor_record "go_mcp_binary" "broken" "rm ${go_bin_path} && harness-mem setup"
       warn "Go MCP binary exists but smoke test failed: ${go_bin_path}"
+      failed=1
     fi
   else
-    _doctor_record "go_mcp_binary" "not_installed" "harness-mem setup (auto-downloads from GitHub Releases)"
+    _doctor_record "go_mcp_binary" "ok:nodejs_fallback" "harness-mem setup (optional: auto-downloads Go binary from GitHub Releases)"
     log "Go MCP binary: not installed (Node.js fallback active)"
   fi
 


### PR DESCRIPTION
## Summary

Unblocks v0.11.0 release CI. The §76 `doctor` Go MCP binary check recorded `status=not_installed` when no Go binary was present, but the wrapper script still falls back to Node.js transparently so this is an acceptable steady state — not a real failure. The old value broke the `doctor --json` contract because `_doctor_emit_json` derives `failed_count` by counting checks whose status is neither `"ok"` nor `"ok:*"`, while `all_green` is derived from a separate `failed` flag inside `doctor_impl`. The Go binary branch bumped `failed_count` without flipping `failed`, so CI saw `all_green=true` alongside `failed_count=1` and `doctor-json-contract.test.ts` failed (Alpha and Beta own-content recall still stay under §77 — this PR is strictly the doctor-contract fix).

## Changes

- Absent Go binary → status `ok:nodejs_fallback` (counted as pass, matches `all_green=true`)
- Broken Go binary (stdio smoke test fails) → set `failed=1` so `all_green=false` matches `failed_count≥1`
- Added inline comment linking the status semantics to the `_doctor_emit_json` contract to prevent future drift

## Test plan

- [x] `bash -n scripts/harness-mem` — syntax OK
- [x] With binary present: `doctor --json` → `all_green=true, failed_count=0, go_mcp_binary.status=ok`
- [x] With binary removed (CI-equivalent): `doctor --json` → `all_green=true, failed_count=0, go_mcp_binary.status=ok:nodejs_fallback`
- [x] `bun test tests/doctor-json-contract.test.ts` → 5/5 PASS in both states
- [ ] CI `release.yml` retries cleanly on the v0.11.0 tag after merge

## Next step after merge

Retag `v0.11.0` on the new merge commit so the release workflow reruns and reaches `publish-npm` + `github-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Go MCPバイナリのステータス報告ロジックを改善し、テスト失敗時の検出精度を向上させました。

* **Documentation**
  * Node.jsフォールバック機能に関する説明を追加し、ステータス報告の動作をより明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->