### PR TITLE
docs: repositioning (project-scoped, tool-agnostic) + industry LoCoMo F1 comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
   <img src="https://raw.githubusercontent.com/Chachamaru127/harness-mem/main/docs/assets/readme/hero.png" alt="Harness-mem — one local memory shared between Claude Code and Codex" width="820" />
 </p>
 
-<p align="center"><strong>Stop re-explaining yesterday's work.</strong><br/>One local memory. Claude Code + Codex. ~5ms cold start. Zero cloud.</p>
+<p align="center"><strong>One project. One memory. Every AI coding agent.</strong></p>
+
+<p align="center">
+  Stop re-explaining yesterday's work to Claude Code, Codex, or Cursor. Harness-mem keeps a single local SQLite memory <em>per project</em> and shares it across every AI coding agent you use. ~5ms cold start. Zero cloud, zero API keys.
+</p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@chachamaru127/harness-mem"><img src="https://img.shields.io/npm/v/@chachamaru127/harness-mem" alt="npm version" /></a>
@@ -79,6 +83,27 @@ All numbers below come from committed artifacts you can rerun yourself — no ma
 | **Bilingual recall@10** | 0.8800 | same manifest |
 
 The Go MCP server is the layer Claude Code and Codex actually talk to. If the Go binary is missing, a wrapper script transparently falls back to the Node.js build — you still get every feature, just at Node.js cold start.
+
+### How this compares (LoCoMo F1, self-reported)
+
+LoCoMo is the reference long-term conversational memory benchmark. The table below lists published F1 scores from each tool's own docs or papers. We do not re-run competitors — we cite their published numbers verbatim, with the evaluation scope column so you can judge comparability yourself.
+
+| Tool | LoCoMo F1 | Scope | Source |
+|---|---:|---|---|
+| **harness-mem** | **0.5917** | LoCoMo 120 Q subset, 3-run PASS, release-gate | [`ci-run-manifest-latest.json`](memory-server/src/benchmark/results/ci-run-manifest-latest.json) |
+| LangMem | 0.581 | LoCoMo (p95 search: 59.82 s) | [2026 comparison](https://dev.to/varun_pratapbhardwaj_b13/5-ai-agent-memory-systems-compared-mem0-zep-letta-supermemory-superlocalmemory-2026-benchmark-59p3) |
+| Kumiho | 0.565 | LoCoMo full (1,986 Q / 10 conversations) | [kumihoclouds/kumiho-benchmarks](https://github.com/kumihoclouds/kumiho-benchmarks) |
+| SimpleMem | 0.432 | LoCoMo (average) | [alphaXiv 2601.02553](https://www.alphaxiv.org/overview/2601.02553v1) |
+| Mem0 (single-hop) | 0.387 | LoCoMo single-hop token-F1 | [arXiv 2504.19413](https://arxiv.org/abs/2504.19413) |
+| claude-mem / Claude built-in memory / ChatGPT memory | — | not published | — |
+
+**Caveats we keep visible**
+
+- harness-mem benchmarks on the LoCoMo **120-question subset**; Kumiho benchmarks on the full 1,986. Subsets can flatter the score — this is **not** an apples-to-apples comparison and we say so explicitly.
+- Mem0 also publishes a **0.669 LLM-as-judge** score vs OpenAI memory (0.529) on a broader metric. harness-mem's 0.5917 is **token-level F1**, not LLM-judge — different axes, different absolute numbers.
+- Letta publishes 0.832 on **LongMemEval**, which is a different benchmark. It is intentionally not in the table above because comparing across benchmarks would mislead.
+- We do not run competitors ourselves — every non-harness number above is a self-reported figure from the source linked in the same row.
+- Watch slices that still fail our Japanese companion gate are listed in [Measured Proof](#measured-proof). We publish those failures on purpose.
 
 Full benchmark gate (primary ship gate + Japanese companion + historical baseline) is in the [Measured Proof](#measured-proof) section below.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -4,7 +4,11 @@
   <img src="https://raw.githubusercontent.com/Chachamaru127/harness-mem/main/docs/assets/readme/hero.png" alt="Harness-mem — Claude Code と Codex で共有する1つのローカルメモリ" width="820" />
 </p>
 
-<p align="center"><strong>昨日の作業を、もう説明し直さなくていい。</strong><br/>Claude Code と Codex で共有する1つのローカルメモリ。コールドスタート ~5ms。クラウド不要。</p>
+<p align="center"><strong>プロジェクトごとに、1つの記憶。すべての AI コーディングエージェントで。</strong></p>
+
+<p align="center">
+  Claude Code にも、Codex にも、Cursor にも、昨日の作業を説明し直さなくていい。harness-mem は<em>プロジェクト単位で</em> 1 つのローカル SQLite を、あなたが使うすべての AI コーディングエージェントに共有します。コールドスタート ~5ms。クラウドゼロ、API キーゼロ。
+</p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@chachamaru127/harness-mem"><img src="https://img.shields.io/npm/v/@chachamaru127/harness-mem" alt="npm version" /></a>
@@ -79,6 +83,27 @@
 | **Bilingual recall@10** | 0.8800 | 同 manifest |
 
 Go MCP サーバーは Claude Code / Codex が実際に通信する層です。Go バイナリが無ければ wrapper script が透過的に Node.js 版にフォールバックします。機能は全部使えて、コールドスタートだけ Node.js 相当になります。
+
+### 他ツールとの比較（LoCoMo F1、全て自社公開値）
+
+LoCoMo は長期会話メモリの代表的なベンチマークです。下表は各ツールが **自分で公開している** F1 スコアをそのまま並べたものです。harness-mem 以外は再計測していません。評価スコープ列を付けているので、公平な比較かは読者側で判断できます。
+
+| ツール | LoCoMo F1 | スコープ | 出典 |
+|---|---:|---|---|
+| **harness-mem** | **0.5917** | LoCoMo 120 Q サブセット、3-run PASS、release gate | [`ci-run-manifest-latest.json`](memory-server/src/benchmark/results/ci-run-manifest-latest.json) |
+| LangMem | 0.581 | LoCoMo（p95 検索: 59.82 秒） | [2026 比較記事](https://dev.to/varun_pratapbhardwaj_b13/5-ai-agent-memory-systems-compared-mem0-zep-letta-supermemory-superlocalmemory-2026-benchmark-59p3) |
+| Kumiho | 0.565 | LoCoMo 全量（1,986 Q / 10 会話） | [kumihoclouds/kumiho-benchmarks](https://github.com/kumihoclouds/kumiho-benchmarks) |
+| SimpleMem | 0.432 | LoCoMo（平均） | [alphaXiv 2601.02553](https://www.alphaxiv.org/overview/2601.02553v1) |
+| Mem0（single-hop） | 0.387 | LoCoMo single-hop token-F1 | [arXiv 2504.19413](https://arxiv.org/abs/2504.19413) |
+| claude-mem / Claude 組み込みメモリ / ChatGPT メモリ | — | 非公開 | — |
+
+**明示しておく前提**
+
+- harness-mem は LoCoMo の **120 問サブセット** で計測しています。Kumiho は全 1,986 問で計測。サブセットの方がスコアが出やすい傾向があります — **同じ土俵ではありません**。ここをはっきり書いておきます。
+- Mem0 は別途 LLM-as-judge で **0.669**（対 OpenAI memory 0.529）という broader metric の数字も公開しています。harness-mem の 0.5917 は **token-level F1** で、LLM-judge ではありません — 軸が違うので絶対値もそのまま比較できません。
+- Letta は **LongMemEval** という別ベンチマークで 0.832 を公開していますが、違うベンチマーク同士の比較は読者を誤解させるのであえて表に入れていません。
+- 他社ツールは私たちの手元では実行していません。表の harness-mem 以外の値は全て各社の公開値をそのまま引用しています。
+- Japanese companion gate で残っている watch slice（fail しているもの）は [実測ベンチマーク](#実測ベンチマーク) セクションに書いています。隠す意味がないので公開しています。
 
 完全な benchmark gate（main ship gate + 日本語 companion + 歴史 baseline）は [実測ベンチマーク](#実測ベンチマーク) セクションに残してあります。
 


### PR DESCRIPTION
## Summary

Two small but load-bearing changes to how harness-mem presents itself:

### 1. Tagline / positioning refresh

The v0.11.0 tagline emphasized "local + fast". This PR adds the actual differentiator on top: **project-scoped memory that any AI coding agent can share.** Naming Claude Code and Codex explicitly in the headline also ages badly — Cursor is already Tier 2 today, Gemini CLI and OpenCode land in experimental, a new agent will arrive next quarter. Replace it with:

> **One project. One memory. Every AI coding agent.**
>
> Stop re-explaining yesterday's work to Claude Code, Codex, or Cursor. Harness-mem keeps a single local SQLite memory *per project* and shares it across every AI coding agent you use. ~5ms cold start. Zero cloud, zero API keys.

The Japanese README mirrors this two-line shape with 「プロジェクトごとに、1つの記憶。すべての AI コーディングエージェントで。」 and a matching sub-tagline.

### 2. Industry LoCoMo F1 comparison table

A quick industry scan surfaced that memory tools split roughly 50/50 on benchmark transparency:

- **Publish**: Mem0, LangMem, Kumiho, SimpleMem, Letta
- **Don't publish**: claude-mem, Claude built-in memory, ChatGPT memory

harness-mem already commits its release-gate manifest, raw bench JSON, reset history file, and Japanese companion watch-slice failures. The honest move is to place our `0.5917` next to the public numbers and keep the caveats visible.

New sub-section `### How this compares (LoCoMo F1, self-reported)` inside `## Measured`:

| Tool | LoCoMo F1 | Scope | Source |
|---|---:|---|---|
| **harness-mem** | **0.5917** | LoCoMo 120 Q subset, 3-run PASS, release-gate | committed manifest |
| LangMem | 0.581 | LoCoMo (p95 search: 59.82 s) | DEV community 2026 comparison |
| Kumiho | 0.565 | LoCoMo full (1,986 Q / 10 conversations) | kumihoclouds/kumiho-benchmarks |
| SimpleMem | 0.432 | LoCoMo (average) | alphaXiv 2601.02553 |
| Mem0 (single-hop) | 0.387 | LoCoMo single-hop token-F1 | arXiv 2504.19413 |
| claude-mem / Claude built-in / ChatGPT memory | — | not published | — |

Followed by an explicit `**Caveats we keep visible**` block that says:

- harness-mem runs on the 120-question subset; Kumiho runs the full 1,986. Not apples-to-apples. We say so out loud.
- Mem0 also publishes 0.669 LLM-as-judge on a broader metric. Ours is token-level F1 on a different axis.
- Letta's 0.832 is on LongMemEval, a different benchmark, so it is intentionally excluded.
- Every non-harness number is self-reported by the linked source; we do not re-run competitors.
- Japanese companion gate watch-slice failures are already published in the Measured Proof section.

Why this matters: the table reaches readers who want numbers, the caveats protect readers who would otherwise be misled, and the subset disclosure protects harness-mem from over-reading its own score. Honest transparency becomes a positioning weapon without overclaiming.

## Test contracts preserved

- `tests/benchmark-claim-ssot.test.ts` — release-gate table, Japanese companion and historical baseline literals unchanged
- `tests/release-docs-contract.test.ts` — `## Release Reproducibility` + `[Unreleased]` preserved
- `tests/readme-plans-rules.test.ts` — English `When starting` / `When complete` and Japanese 着手時 / 完了時 subsections preserved
- `tests/marketplace-schema.test.ts` — wrapper-script contract unchanged
- **Full `npm test`**: 0 fail on this branch

## Test plan

- [x] Rewrite EN tagline as two-line headline + sub-tagline
- [x] Rewrite JA tagline to match
- [x] Add English LoCoMo F1 comparison sub-section with caveats block
- [x] Add Japanese LoCoMo F1 comparison sub-section with localized caveats block
- [x] `bun test tests/benchmark-claim-ssot.test.ts tests/release-docs-contract.test.ts tests/readme-plans-rules.test.ts tests/marketplace-schema.test.ts` → 36/36 pass
- [x] Full `npm test` → 0 fail
- [ ] Merge and verify new tagline renders on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* 複数のAIコーディングエージェント間で共有される単一プロジェクトメモリという製品ポジショニングを明確化
* 他製品との比較表（LoCoMo F1スコア、対応範囲、出典）を追加
* 測定対象範囲、評価方法の違い、ベンチマーク除外項目など、測定条件の留意事項を文書化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->