### PR TITLE
chore: ignore mcp-server-go cross-build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ memory-server/src/benchmark/results/freeze-run-*.tsv
 memory-server/src/benchmark/results/ci-run-manifest-history.jsonl
 memory-server/src/benchmark/results/retrospective-*.json
 memory-server/src/benchmark/results/retrospective-*.jsonl
+
+# mcp-server-go cross-build artifacts (tracked `bin/harness-mcp-server` is preserved)
+bin/harness-mcp-darwin-*
+bin/harness-mcp-linux-*
+bin/harness-mcp-windows-*
+mcp-server-go/bin/


### PR DESCRIPTION
## Summary

- `bin/harness-mcp-server` だけが repo に tracked で配布される唯一の MCP binary。
- Cross-build 成果物 `bin/harness-mcp-{darwin,linux,windows}-*` と `mcp-server-go/bin/` 配下は local のみに置くべき artifacts だが、`.gitignore` に未定義で毎回 `git status` に出てきていた。
- Negation-safe な glob（`harness-mcp-darwin-*` 等）で 4 行追加し、既存の tracked `bin/harness-mcp-server` には触れない。

## Why

Build 後の `git status` ノイズ、`git add -A` での誤 commit リスク、PR review 時の confusion を削減。`**/dist/` や `memory-server/src/benchmark/results/freeze-run-*` と同じ local-only policy を適用するだけ。

## Test plan

- [x] `git status` から `bin/harness-mcp-darwin-arm64` と `mcp-server-go/bin/` の untracked 表示が消える
- [x] `git ls-files bin/harness-mcp-server` は依然として tracked
- [ ] 新規 clone + `make build` 後の `git status` が clean なことを reviewer が確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)