### PR TITLE
legal: establish CAN AI LLC as licensor + renumber section to §82

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to harness-mem
+
+Thank you for your interest in contributing to **harness-mem**. Please read
+this document before opening an issue or pull request.
+
+---
+
+## License and Contributor Agreement
+
+harness-mem is licensed under the **Business Source License 1.1 (BSL)**.
+See the [LICENSE](./LICENSE) file for full terms and the [NOTICE](./NOTICE)
+file for a non-binding summary.
+
+By submitting a pull request, bug report, feature request, or any other
+contribution to this repository, you agree to the following:
+
+1. **License grant**. You license your contribution to CAN AI LLC and all
+   recipients of the software under the same Business Source License 1.1
+   that governs this project.
+
+2. **Broad license grant for relicensing**. You grant CAN AI LLC a
+   perpetual, worldwide, non-exclusive, royalty-free, irrevocable license
+   — with the right to sublicense — to use, reproduce, modify, distribute,
+   and relicense your contribution, including under a commercial license
+   or a future open source license of CAN AI LLC's choosing.
+
+   This is an *inbound license grant*, not a copyright assignment — you
+   retain ownership of your contribution. The grant is deliberately broad
+   so that CAN AI LLC can offer commercial licenses for use cases that
+   fall outside the BSL's Additional Use Grant (for example, offering
+   harness-mem as a managed Memory Service).
+
+3. **Originality**. You represent that your contribution is your original
+   work, or that you have the right to submit it under the terms above,
+   and that it does not knowingly infringe any third party's rights.
+
+4. **No warranty**. Your contribution is provided "as is", without
+   warranty of any kind.
+
+5. **Moral rights waiver (for contributors subject to jurisdictions
+   recognizing moral rights, including Japan)**. To the maximum extent
+   permitted by applicable law, you agree not to assert any moral rights
+   (including the rights of attribution and integrity, and in Japan,
+   著作者人格権) against CAN AI LLC, its successors, assigns, sublicensees,
+   or downstream users of the Licensed Work, in respect of your
+   contribution. This waiver does not affect your right to be credited in
+   commit history or release notes where reasonable.
+
+If you cannot agree to these terms, please do not submit contributions.
+
+---
+
+## Before You Open a Pull Request
+
+- **Issues first**. For non-trivial changes, open an issue describing the
+  problem or proposal before writing code. This avoids wasted work.
+- **One concern per PR**. Keep pull requests focused. Separate refactors
+  from feature work.
+- **Tests**. New functionality should include tests. Bug fixes should
+  include a regression test where practical.
+- **Conventional-style commits**. Prefix commits with `feat:`, `fix:`,
+  `docs:`, `refactor:`, `test:`, `chore:` so the history stays scannable.
+
+---
+
+## Development Setup
+
+See the component-specific READMEs:
+
+- [`mcp-server/README.md`](./mcp-server/README.md) — Node/TypeScript MCP server
+- [`mcp-server-go/`](./mcp-server-go/) — Go MCP server
+- [`harness-mem-ui/`](./harness-mem-ui/) — UI
+- [`memory-server/`](./memory-server/) — Memory daemon
+
+---
+
+## Trademarks
+
+"harness-mem" and associated logos are trademarks of CAN AI LLC. See
+[TRADEMARK.md](./TRADEMARK.md) for acceptable-use rules. Briefly: you may
+refer to harness-mem by name when discussing or integrating with it, but
+forks and derivative distributions must use a different name.
+
+---
+
+## Contact
+
+For commercial licensing, partnership inquiries, or questions that are
+not suitable for public issues, please reach out via the repository's
+GitHub profile: https://github.com/Chachamaru127/harness-mem
+
+— CAN AI LLC

--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,9 @@ Business Source License 1.1
 
 Parameters
 
-Licensor:             Claude Code Harness
+Licensor:             CAN AI LLC
 Licensed Work:        harness-mem
-                      The Licensed Work is (c) 2026 Claude Code Harness.
+                      The Licensed Work is (c) 2026 CAN AI LLC.
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you do not use the Licensed Work for a Memory Service.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,76 @@
+harness-mem
+Copyright (c) 2026 CAN AI LLC
+
+-------------------------------------------------------------------------------
+License
+-------------------------------------------------------------------------------
+
+This software is licensed under the Business Source License 1.1 (BSL).
+See the LICENSE file at the repository root for the full, legally binding
+terms. The summary below is informational only and does not override the
+LICENSE file.
+
+Summary (non-binding)
+---------------------
+
+- Source code is available for reading, modification, internal use,
+  personal and non-commercial use, development, testing, and evaluation.
+- You MAY NOT use this software to provide a commercial "Memory Service"
+  to third parties — that is, a managed service whose memory storage,
+  retrieval, or synchronization functionality is substantially derived
+  from this software.
+- On the Change Date (2029-03-08), or four years after the first public
+  distribution of a given version (whichever is earlier), that version
+  automatically relicenses to Apache License, Version 2.0.
+
+Commercial Licensing
+--------------------
+
+For use cases that fall outside the BSL's Additional Use Grant —
+including offering a managed Memory Service, embedding harness-mem in
+a closed-source commercial product, or any other arrangement that
+requires removal of the BSL restrictions — a separate commercial
+license is available from CAN AI LLC.
+
+Contact channels (in order of preference):
+  1. GitHub Discussions (public, for general licensing questions):
+     https://github.com/Chachamaru127/harness-mem/discussions
+  2. GitHub Issue with label "licensing" (for specific requests):
+     https://github.com/Chachamaru127/harness-mem/issues
+  3. For legal notices requiring a written address, please open a
+     GitHub Discussion requesting contact details; CAN AI LLC will
+     respond with the appropriate channel.
+
+CAN AI LLC will publish a dedicated legal contact email on the project
+website prior to accepting commercial license applications.
+
+-------------------------------------------------------------------------------
+Trademarks
+-------------------------------------------------------------------------------
+
+"harness-mem" and any associated logos and marks are trademarks of
+CAN AI LLC. The BSL grants you rights to the source code; it does
+NOT grant you rights to use the "harness-mem" name or logo to promote
+derivative works, forks, or competing services.
+
+If you distribute a modified version, you must use a different name
+that is not confusingly similar to "harness-mem".
+
+-------------------------------------------------------------------------------
+Contributions
+-------------------------------------------------------------------------------
+
+Contributions to this project are accepted under the terms described in
+CONTRIBUTING.md. By submitting a pull request, contributors agree that
+their contributions are licensed under the same Business Source License
+1.1 and assign the necessary rights to CAN AI LLC to enable future
+relicensing (including dual-licensing for commercial use).
+
+-------------------------------------------------------------------------------
+Third-Party Components
+-------------------------------------------------------------------------------
+
+This product includes software developed by third parties, distributed
+under their respective open source licenses. See the dependency manifests
+(package.json, go.mod, etc.) and individual component directories for
+details.

--- a/Plans.md
+++ b/Plans.md
@@ -31,6 +31,74 @@
 
 ---
 
+## §79 Pro 日本語差別化: Ruri Tiered Routing + 独自 API — cc:WIP
+
+策定日: 2026-04-12
+背景: 現状の Pro 経路 (`pro-api-provider.ts`) は汎用側のみ OpenAI `text-embedding-3-large` に差し替える設計で、**日本語側は Free/Pro で同一 (`ruri-v3-30m`)**。harness-mem のブランド "日本語に強い AI coding memory" と価値提案が噛み合わず、Pro が「OpenAI 転売」になってしまう。差別化を技術資産として内製化するため、**日本語ルートを Pro で大型モデル (`ruri-v3-310m`) + CAN AI 独自 API に切り替える**方向へ再設計する。
+
+**設計原則** (UX 損失防止):
+1. Pro は完全 opt-in (`HARNESS_MEM_PRO_API_KEY` + URL 未設定なら挙動不変)
+2. Free 側のコードパスを一切壊さない (既存 `ruri-v3-30m` + `multilingual-e5` 維持)
+3. Pro 失敗時は Free に自動フォールバック (既存の adaptive-provider 機構を流用)
+4. 既存 `mem_vectors` の複合キー設計を利用して 30m/310m を共存保存
+5. 既存ベンチマーク (LoCoMo F1 0.5917) は Pro 実装後も同じ数字で再現可能
+6. Pro ベンチ結果は `ci-run-manifest-pro-latest.json` に別ファイル分離
+7. 段階的 feature flag (`HARNESS_MEM_PRO_JA_ROUTE=1`) で merge 隠蔽
+
+**作業ブランチ**: `feature/pro-japanese-differentiation` (worktree: `../harness-mem-feature-pro-ja`)
+
+**Phase 0-1 調査タスク** (並列実行中):
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| S79-001 | [P] ruri-v3-310m 実機検証 | `harness-mem model pull ruri-v3-310m` で download、ONNX load、1 embed サンプル取得、メモリ使用量/latency/ディスク使用量を計測し `docs/pro-api-redesign-2026-04.md` に記録 | - | cc:WIP |
+| S79-002 | [P] ベクトル次元 256→1024 の移行戦略設計 | `mem_vectors` の複合キー `(observation_id, model)` で 30m/310m を共存保存する contract 確認。新規保存は 310m、既存 30m は lazy re-index の ON/OFF を決定。schema 変更の要否を判定し設計 doc に記録 | - | cc:WIP |
+| S79-003 | [P] transformers.js の ruri-v3-310m 対応確認 | `@huggingface/transformers` で `cl-nagoya/ruri-v3-310m` の ONNX model と tokenizer をロードできるか検証。tokenizer は WordPiece 変換問題が過去に 30m で発生したので要注意 | - | cc:WIP |
+| S79-004 | [P] Free vs Pro ベンチマーク仕様書 | `run-ci.ts` を Pro 経路でも走らせる CI 拡張設計。`ci-run-manifest-pro-latest.json` schema 定義、Free vs Pro 比較表の出力 format、差分判定閾値。設計 doc に記録 | - | cc:WIP |
+| S79-005 | [P] Pro API サーバー技術選定 | Node.js (transformers.js) / Go (onnx-go) / Python (transformers) の比較表。Fly.io / Cloud Run / Railway のコスト試算 (ruri-v3-310m + 1.2GB + CPU インスタンスで最小 ~¥3,000/月 想定)。MVP 推奨構成を決定 | - | cc:WIP |
+| S79-006 | [P] JMTEB / LoCoMo 公式スコア収集 | ruri-v3-30m (72.95) と ruri-v3-310m の公式 JMTEB スコア確認。他日本語 embedding 比較表 | - | cc:WIP |
+| S79-007 | 設計ドキュメント `docs/pro-api-redesign-2026-04.md` drafting | 上記 S79-001〜006 の調査結果を統合した設計 doc を feature branch に永続化。現状分析 / 新設計 / feature flag gate / PR 分割 / UX 損失防止ルール / Phase ロードマップを含む | S79-001..006 | cc:TODO |
+
+**Phase 2 実装タスク** (調査結果確定後に着手):
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| S79-010 | PR #1: `pro-api-provider` の日本語ルート拡張 | `ruri-v3-310m` を想定したモデル指定、prefix `query: / passage:`、1024次元対応、feature flag off で既存テスト全 PASS | S79-007 | cc:TODO |
+| S79-011 | PR #2: `registry.ts` と `adaptive-provider.ts` の japaneseProvider 切替ロジック | `HARNESS_MEM_PRO_JA_ROUTE=1` 時のみ Pro 日本語 API に切替。未設定時は現状 `ruri-v3-30m` | S79-010 | cc:TODO |
+| S79-012 | PR #3: 別 private repo `canai-ops/harness-mem-pro-api` の MVP サーバー実装 | Node.js + @huggingface/transformers + ruri-v3-310m の最小 HTTP サーバー (POST /v1/embeddings)、API key 認証、LRU キャッシュ、health check、Fly.io deploy | S79-007, S79-005 | cc:TODO |
+| S79-013 | PR #4: Pro 経路の E2E ベンチマーク | `run-ci.ts` を Pro 経路で走らせる CI ジョブ追加、`ci-run-manifest-pro-latest.json` 出力、Free vs Pro の F1 差分を CHANGELOG で報告 | S79-012, S79-010, S79-011 | cc:TODO |
+| S79-014 | PR #5: ドキュメント更新 | `docs/adaptive-retrieval.md` と `docs/pro-api-data-policy.md` を新設計 (CAN AI 独自 API 前提) に書き直し | S79-013 | cc:TODO |
+| S79-015 | PR #6: feature flag 削除 + GA | `HARNESS_MEM_PRO_JA_ROUTE` flag を削除して正式機能化、v0.12.0 でリリース | S79-014 | cc:TODO |
+
+---
+
+## §78 Legal Refresh: CAN AI LLC + Open Core 整理 — cc:WIP
+
+策定日: 2026-04-11
+背景: 以下の法的リスクが発見された: (1) LICENSE の Licensor が `Claude Code Harness` という曖昧表記で BSL 違反時の権利行使主体が不明、(2) `mcp-server/package.json` の license が誤って `MIT` のまま (本来は Open Core 意図どおり)、(3) `mcp-server/README.md` で `@anthropic-ai/harness-mcp-server` という Anthropic 公式 scope を誤用、(4) CLA 不在で将来の商用ライセンス販売が不可能、(5) README で `CAN AI Inc.` と表記されるが実態は合同会社 (正しい英訳は LLC)。これらを一括で塞ぐ。
+
+**方針**: Open Core 戦略を維持 (ルート = BSL、mcp-server/sdk/vscode-extension = MIT)。CAN AI LLC を実在する Licensor として確定。
+
+**作業ブランチ**: `legal/refresh-can-ai-llc-2026-04`
+
+| Task | 内容 | DoD | Status |
+|------|------|-----|--------|
+| S78-001 | LICENSE の Licensor を `CAN AI LLC` に確定 | `LICENSE` の Licensor 行と Copyright 行が `CAN AI LLC` になっている | cc:完了 |
+| S78-002 | NOTICE 新規作成 | BSL 要約、商標通告、CLA 意図、商用ライセンス窓口 (GitHub Discussions 暫定) を含む NOTICE がルートに存在 | cc:完了 |
+| S78-003 | CONTRIBUTING.md 新規作成 | License grant 条項、moral rights waiver (日本法 著作者人格権不行使)、originality、no warranty を含む CONTRIBUTING.md がルートに存在 | cc:完了 |
+| S78-004 | TRADEMARK.md 新規作成 | harness-mem 名称・ロゴの使用ポリシー (nominative fair use / 禁止事項 / フェアユース / エンフォースメント) を含む TRADEMARK.md がルートに存在 | cc:完了 |
+| S78-005 | Anthropic 商標侵害の除去 | `mcp-server/README.md` の `@anthropic-ai/harness-mcp-server` 参照を `@canai/mcp-server` に置換済み | cc:完了 |
+| S78-006 | mcp-server / memory-server の scope 変更 | `@claude-code-harness/*` → `@canai/*` に変更済み (商標リスク回避) | cc:完了 |
+| S78-007 | mcp-server license rollback (Open Core 維持) | `mcp-server/package.json` の license を `MIT` に戻し、`mcp-server/README.md` の License 節も MIT + Open Core 説明に差し替え | cc:完了 |
+| S78-008 | README の `CAN AI Inc.` → `CAN AI LLC` 統一 | `README.md:575` と `README_ja.md:571` の表記を統一 | cc:完了 |
+| S78-009 | sdk / vscode-extension に author 追加 | `sdk/package.json` と `vscode-extension/package.json` に `"author": "CAN AI LLC"` を追加 (license は MIT 維持) | cc:完了 |
+| S78-010 | Plans.md に §78 と §79 を追記 | 本ドキュメントが Plans.md に永続化される | cc:WIP |
+| S78-011 | commit + PR 作成 | `legal/refresh-can-ai-llc-2026-04` ブランチでコミット、PR を main に向けて作成 | cc:TODO |
+
+**リリースブロッカー**: v0.12.0 までに S78 を main にマージしておくこと。
+
+---
+
 ## §77 Retrieval Quality Regression 調査 — cc:TODO
 
 **背景**: v0.11.0 リリース作業中、`memory-server/src` が v0.9.0 以降 1 行も変更されていないにもかかわらず、以下の retrieval 指標が劣化していることが判明した:

--- a/Plans.md
+++ b/Plans.md
@@ -72,7 +72,7 @@
 
 ---
 
-## §78 Legal Refresh: CAN AI LLC + Open Core 整理 — cc:WIP
+## §82 Legal Refresh: CAN AI LLC + Open Core 整理 — cc:WIP
 
 策定日: 2026-04-11
 背景: 以下の法的リスクが発見された: (1) LICENSE の Licensor が `Claude Code Harness` という曖昧表記で BSL 違反時の権利行使主体が不明、(2) `mcp-server/package.json` の license が誤って `MIT` のまま (本来は Open Core 意図どおり)、(3) `mcp-server/README.md` で `@anthropic-ai/harness-mcp-server` という Anthropic 公式 scope を誤用、(4) CLA 不在で将来の商用ライセンス販売が不可能、(5) README で `CAN AI Inc.` と表記されるが実態は合同会社 (正しい英訳は LLC)。これらを一括で塞ぐ。
@@ -83,19 +83,19 @@
 
 | Task | 内容 | DoD | Status |
 |------|------|-----|--------|
-| S78-001 | LICENSE の Licensor を `CAN AI LLC` に確定 | `LICENSE` の Licensor 行と Copyright 行が `CAN AI LLC` になっている | cc:完了 |
-| S78-002 | NOTICE 新規作成 | BSL 要約、商標通告、CLA 意図、商用ライセンス窓口 (GitHub Discussions 暫定) を含む NOTICE がルートに存在 | cc:完了 |
-| S78-003 | CONTRIBUTING.md 新規作成 | License grant 条項、moral rights waiver (日本法 著作者人格権不行使)、originality、no warranty を含む CONTRIBUTING.md がルートに存在 | cc:完了 |
-| S78-004 | TRADEMARK.md 新規作成 | harness-mem 名称・ロゴの使用ポリシー (nominative fair use / 禁止事項 / フェアユース / エンフォースメント) を含む TRADEMARK.md がルートに存在 | cc:完了 |
-| S78-005 | Anthropic 商標侵害の除去 | `mcp-server/README.md` の `@anthropic-ai/harness-mcp-server` 参照を `@canai/mcp-server` に置換済み | cc:完了 |
-| S78-006 | mcp-server / memory-server の scope 変更 | `@claude-code-harness/*` → `@canai/*` に変更済み (商標リスク回避) | cc:完了 |
-| S78-007 | mcp-server license rollback (Open Core 維持) | `mcp-server/package.json` の license を `MIT` に戻し、`mcp-server/README.md` の License 節も MIT + Open Core 説明に差し替え | cc:完了 |
-| S78-008 | README の `CAN AI Inc.` → `CAN AI LLC` 統一 | `README.md:575` と `README_ja.md:571` の表記を統一 | cc:完了 |
-| S78-009 | sdk / vscode-extension に author 追加 | `sdk/package.json` と `vscode-extension/package.json` に `"author": "CAN AI LLC"` を追加 (license は MIT 維持) | cc:完了 |
-| S78-010 | Plans.md に §78 と §79 を追記 | 本ドキュメントが Plans.md に永続化される | cc:WIP |
-| S78-011 | commit + PR 作成 | `legal/refresh-can-ai-llc-2026-04` ブランチでコミット、PR を main に向けて作成 | cc:TODO |
+| S82-001 | LICENSE の Licensor を `CAN AI LLC` に確定 | `LICENSE` の Licensor 行と Copyright 行が `CAN AI LLC` になっている | cc:完了 |
+| S82-002 | NOTICE 新規作成 | BSL 要約、商標通告、CLA 意図、商用ライセンス窓口 (GitHub Discussions 暫定) を含む NOTICE がルートに存在 | cc:完了 |
+| S82-003 | CONTRIBUTING.md 新規作成 | License grant 条項、moral rights waiver (日本法 著作者人格権不行使)、originality、no warranty を含む CONTRIBUTING.md がルートに存在 | cc:完了 |
+| S82-004 | TRADEMARK.md 新規作成 | harness-mem 名称・ロゴの使用ポリシー (nominative fair use / 禁止事項 / フェアユース / エンフォースメント) を含む TRADEMARK.md がルートに存在 | cc:完了 |
+| S82-005 | Anthropic 商標侵害の除去 | `mcp-server/README.md` の `@anthropic-ai/harness-mcp-server` 参照を `@canai/mcp-server` に置換済み | cc:完了 |
+| S82-006 | mcp-server / memory-server の scope 変更 | `@claude-code-harness/*` → `@canai/*` に変更済み (商標リスク回避) | cc:完了 |
+| S82-007 | mcp-server license rollback (Open Core 維持) | `mcp-server/package.json` の license を `MIT` に戻し、`mcp-server/README.md` の License 節も MIT + Open Core 説明に差し替え | cc:完了 |
+| S82-008 | README の `CAN AI Inc.` → `CAN AI LLC` 統一 | `README.md:575` と `README_ja.md:571` の表記を統一 | cc:完了 |
+| S82-009 | sdk / vscode-extension に author 追加 | `sdk/package.json` と `vscode-extension/package.json` に `"author": "CAN AI LLC"` を追加 (license は MIT 維持) | cc:完了 |
+| S82-010 | Plans.md に §82 と §79 を追記 | 本ドキュメントが Plans.md に永続化される | cc:WIP |
+| S82-011 | commit + PR 作成 | `legal/refresh-can-ai-llc-2026-04` ブランチでコミット、PR を main に向けて作成 | cc:TODO |
 
-**リリースブロッカー**: v0.12.0 までに S78 を main にマージしておくこと。
+**リリースブロッカー**: v0.12.0 までに §82 を main にマージしておくこと。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Update the marker to `cc:完了` and note any unresolved issues.
 ## Maintained by
 
 <p align="center">
-  Developed and maintained by <a href="https://canai.jp/">CAN AI Inc.</a><br />
+  Developed and maintained by <a href="https://canai.jp/">CAN AI LLC</a><br />
   AI adoption consulting — helping organizations build lasting AI capabilities.
 </p>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -567,7 +567,7 @@ harness-mem ではタスク管理の single source of truth として `Plans.md`
 ## 開発・運営
 
 <p align="center">
-  開発・運営: <a href="https://canai.jp/">CAN AI Inc.</a><br />
+  開発・運営: <a href="https://canai.jp/">CAN AI LLC</a><br />
   AI 定着コンサルティング — AI を組織の当たり前にする伴走。
 </p>
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,82 @@
+# harness-mem Trademark Policy
+
+**Last updated: 2026-04-11**
+
+"harness-mem", the harness-mem logo, and any associated marks
+(collectively, the "Marks") are trademarks of **CAN AI LLC**.
+
+The Business Source License 1.1 under which harness-mem is distributed
+grants you rights in the **source code**. It does **not** grant you any
+rights in the Marks. This policy describes how you may — and may not —
+use the Marks.
+
+---
+
+## What you MAY do without asking
+
+You may use the name "harness-mem" (in plain text, without stylization)
+for the following non-promotional purposes:
+
+- **Nominative reference**. Stating that your software uses, integrates
+  with, depends on, or is compatible with harness-mem. For example:
+  *"This plugin adds harness-mem support to Foo."*
+- **Accurate descriptions**. Blog posts, tutorials, academic papers,
+  reviews, comparison articles, and conference talks about harness-mem.
+- **Bug reports and discussion**. Issues, discussions, and community
+  forums.
+
+When you do this, please:
+
+- Use "harness-mem" exactly, in lowercase, as one word with a hyphen.
+- Do not alter the logo's colors, proportions, or composition.
+- Do not imply that your project is endorsed by, affiliated with, or
+  sponsored by CAN AI LLC unless it actually is.
+
+---
+
+## What you MAY NOT do without written permission
+
+- **Naming a fork or derivative**. If you fork harness-mem and
+  redistribute it — whether modified or not — you must use a **different
+  name** that is not confusingly similar to "harness-mem". For example,
+  `harness-mem-plus`, `harness-memory`, or `hmem-fork` are **not**
+  acceptable. Pick a genuinely distinct name.
+- **Naming a competing product or service**. You may not use "harness-mem"
+  or a confusingly similar name for a product, service, company, domain
+  name, or social media account.
+- **Using the logo as your own**. You may not use the harness-mem logo
+  as the primary logo of your own product, project, company, or service.
+- **Modifying the logo**. You may not recolor, distort, redraw, or
+  recompose the logo. Use the official SVG assets as provided.
+- **Implying endorsement**. You may not suggest that CAN AI LLC endorses,
+  sponsors, or supports your product, service, event, or organization.
+- **Merchandise**. You may not sell merchandise (t-shirts, stickers,
+  mugs, etc.) featuring the Marks.
+
+---
+
+## Fair use and quotation
+
+Nothing in this policy is intended to restrict your fair-use rights
+under applicable trademark law, including nominative fair use, parody,
+commentary, and news reporting.
+
+---
+
+## Requesting permission
+
+For any use not covered above — including commercial licensing, logo
+use in marketing materials, or partnership arrangements — please
+contact CAN AI LLC via the repository's GitHub profile:
+
+https://github.com/Chachamaru127/harness-mem
+
+---
+
+## Enforcement
+
+CAN AI LLC reserves the right to enforce its trademark rights against
+any unauthorized use of the Marks. If you believe someone is misusing
+the Marks, please let us know.
+
+— CAN AI LLC

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # Harness MCP Server
 
-MCP (Model Context Protocol) server for Claude Code Harness.
+MCP (Model Context Protocol) server for harness-mem.
 Enables cross-client session communication between Claude Code, Codex, Cursor, and other MCP-compatible AI tools.
 
 ## Features
@@ -14,7 +14,7 @@ Enables cross-client session communication between Claude Code, Codex, Cursor, a
 
 ```bash
 # From npm (when published)
-npm install -g @anthropic-ai/harness-mcp-server
+npm install -g @canai/mcp-server
 
 # From source
 cd mcp-server
@@ -32,7 +32,7 @@ npm run build
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["@anthropic-ai/harness-mcp-server"]
+      "args": ["@canai/mcp-server"]
     }
   }
 }
@@ -46,7 +46,7 @@ npm run build
   "servers": {
     "harness": {
       "command": "npx",
-      "args": ["@anthropic-ai/harness-mcp-server"]
+      "args": ["@canai/mcp-server"]
     }
   }
 }
@@ -59,7 +59,7 @@ npm run build
 {
   "harness": {
     "command": "npx",
-    "args": ["@anthropic-ai/harness-mcp-server"]
+    "args": ["@canai/mcp-server"]
   }
 }
 ```
@@ -167,4 +167,18 @@ mcp-server/
 
 ## License
 
-MIT - Same as Claude Code Harness
+MIT — as declared in this package's `package.json`.
+
+Note that the overall **harness-mem distribution** (including this
+sub-package when bundled) is published under the **Business Source
+License 1.1** at the repository root. The MIT designation on this
+individual sub-package reflects the **Open Core** structure: the MCP
+integration surface is intentionally kept permissive so that AI clients
+(Claude Code, Codex, Cursor, Zed, etc.) can freely integrate with
+harness-mem, while the core memory runtime and overall distribution
+remain under BSL to protect the commercial offering.
+
+See the repository root [LICENSE](../LICENSE) and [NOTICE](../NOTICE)
+for the distribution-level terms.
+
+Copyright (c) 2026 CAN AI LLC

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@claude-code-harness/mcp-server",
+  "name": "@canai/mcp-server",
   "version": "1.0.0",
-  "description": "MCP Server for Claude Code Harness - enables cross-client session communication",
+  "description": "MCP Server for harness-mem - enables cross-client session communication",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
@@ -21,7 +21,7 @@
     "ai",
     "codex"
   ],
-  "author": "Claude Code Harness",
+  "author": "CAN AI LLC",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1"

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Harness MCP Server
  *
- * Enables cross-client session communication for Claude Code Harness.
+ * Enables cross-client session communication for harness-mem.
  * Supports Claude Code, Codex, and other MCP-compatible clients.
  *
  * Usage:

--- a/memory-server/package.json
+++ b/memory-server/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "@claude-code-harness/memory-server",
+  "name": "@canai/memory-server",
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "author": "CAN AI LLC",
+  "license": "BUSL-1.1",
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch run src/index.ts",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -27,6 +27,7 @@
     "ai",
     "claude"
   ],
+  "author": "CAN AI LLC",
   "license": "MIT",
   "devDependencies": {
     "@types/bun": "latest",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -17,6 +17,7 @@
     "claude",
     "harness"
   ],
+  "author": "CAN AI LLC",
   "license": "MIT",
   "activationEvents": [],
   "main": "./dist/extension.js",


### PR DESCRIPTION
## Summary

- 公開 repo 監査で見つかった **5 つの法的リスク** を一括で解消。Open Core 構造 (root BSL 1.1 / sub-packages MIT) は維持。
- LICENSE の Licensor を曖昧表記 `Claude Code Harness` から **CAN AI LLC** に確定、`NOTICE` / `CONTRIBUTING.md` / `TRADEMARK.md` を新設、`@anthropic-ai/*` 商標誤用と `@claude-code-harness/*` scope を **`@canai/*`** に移行、`mcp-server` の license は MIT に戻す (Open Core 境界を復元)、`CAN AI Inc.` → `CAN AI LLC` (合同会社の正しい英訳)。
- rebase 後、main §78 が "World-class Retrieval" に pivot していたため、この branch の legal refresh section を **§78 → §82** にリネーム（content は変更なし）。

## Commits

1. `7923be5` — `legal: establish CAN AI LLC as licensor and tighten IP protection`
   (rebased on top of current main, content identical to original 7c450ac)
2. `7c520bb` — `docs: renumber legal refresh section §78 → §82 after main §78 pivot`
   (renumber only: `## §78 Legal Refresh` → `## §82 Legal Refresh`, `S78-001..011` → `S82-001..011`, 2 in-body refs)

## Why §82

- §77 / §78 (main) / §79 (this branch legacy Pro design) / §80 (feature branch Pro API Concierge) / §81 (PR #45 agentmemory) は既に使用中
- §82 が最初の空きスロット

## Related PRs

- PR #45 `docs/s81-agentmemory-cross-pollination` — 別セッションの §80 draft を §81 に renumber
- PR #47 `fix/s81-002-model-catalog-ruri-130m` — Ruri model catalog 訂正
- `feature/pro-japanese-differentiation` — 同じく未 PR (このあと rebase して PR 作成予定)

## Test plan

- [x] `LICENSE` の Licensor / Copyright 行が `CAN AI LLC`
- [x] `NOTICE` / `CONTRIBUTING.md` / `TRADEMARK.md` が存在
- [x] `mcp-server/package.json` の license は `MIT` (Open Core 維持)
- [x] `@anthropic-ai/harness-mcp-server` 参照が repo 全体から消滅
- [x] `@claude-code-harness/*` scope が `@canai/*` に置換
- [x] `README.md` / `README_ja.md` の `CAN AI Inc.` が `CAN AI LLC` に
- [x] Plans.md に §78 が 2 つ並んで現れる状態が解消 (§82 = legal, §78 = World-class)
- [ ] Reviewer: BSL 1.1 / MIT の両方が適用されている sub-packages の license ファイル整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)