### PR TITLE
chore(release): sync plugin.json + marketplace.json to 0.13.0 (hotfix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode, Gemini CLI)",
-  "version": "0.11.0",
+  "version": "0.13.0",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.11.0",
+      "version": "0.13.0",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.11.0",
+  "version": "0.13.0",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",


### PR DESCRIPTION
## Summary

- Bump `.claude-plugin/plugin.json` version from 0.11.0 → 0.13.0
- Bump `.claude-plugin/marketplace.json` metadata.version and plugins[harness-mem].version from 0.11.0 → 0.13.0

## Why

The v0.12.0 release workflow (run #24604004750) failed at the `repository behavior gate` because `tests/marketplace-schema.test.ts` enforces that `plugin.json` / `marketplace.json` versions match `package.json`. The version bumps to `package.json` in the merged PRs #51 / #52 did not also bump the plugin manifest files. v0.13.0 workflow (in progress) is expected to hit the same failure.

## Test plan

- [x] `bun test tests/marketplace-schema.test.ts` — 22 pass / 0 fail locally
- [x] After merge: delete failed v0.13.0 tag, recreate on main HEAD (this commit), re-trigger release workflow
- [x] Release workflow passes repo behavior gate on re-run