### PR TITLE
test(locomo): per-test timeout 30s for 15-sample full eval

### DIFF
--- a/tests/locomo-full-eval.test.ts
+++ b/tests/locomo-full-eval.test.ts
@@ -62,5 +62,5 @@ describe("HARDEN-006: maxSamples 伝播バグ回帰テスト", () => {
     expect(result.dataset_info.total_samples).toBe(15);
     expect(result.dataset_info.evaluated_samples).toBe(15);
     expect(result.metrics.overall.count).toBe(45);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Step 14 (repo behavior gate) flakes on HARDEN-006 15-sample test hitting default 5000ms timeout. Per-test timeout raised to 30s.