### PR TITLE
docs(changelog): note v0.12.0 consolidation into v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,16 @@ The API response shape gained new fields (`raw_text`, `wake_up_context`, `includ
 - Integration suite: 182 pass / 8 skip / 0 fail across 32 files (api-contract snapshot refreshed).
 - Go suite: all 6 packages ok (auth, pii, proxy, tools, types, util).
 
-## [0.12.0] - 2026-04-18
+## [0.12.0] — consolidated into [0.13.0]
+
+> **Note**: v0.12.0 was tagged and the release workflow was attempted on 2026-04-18, but
+> the repository-behavior / typecheck / dev-domain gates surfaced multiple latent issues
+> that required 9 hotfix PRs (#53–#61) before `release.yml` could complete end-to-end.
+> Rather than skip versions on npm, the v0.12.0 tag was **deleted** and its content was
+> **consolidated into v0.13.0**. The v0.12.0 section below is retained as the historical
+> record of what the consolidation covers (Phase A + parallel-session §81 cross-pollination);
+> v0.13.0 adds Phase B–E (§78-B/C/D/E verbatim storage, graph memory, procedural skills,
+> etc.) on top of that same content. **Users should install v0.13.0 to get everything.**
 
 ### Theme: Dual-agent coordination, lifecycle hygiene, and user-facing onboarding polish
 


### PR DESCRIPTION
v0.12.0 tag was deleted after release workflow needed 9 hotfix PRs to stabilize; its content consolidated into v0.13.0. Retained historical section with explicit note directing users to v0.13.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * チェンジログを更新し、v0.12.0がv0.13.0に統合されたことを記載しました。v0.12.0タグが削除されたため、v0.13.0のインストールをお勧めします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->