### PR TITLE
feat(search): expose observation_type via MCP + OpenAPI + type: prefix (§89-001 Step 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-_No unreleased changes yet. New user-visible work lands here before the next version bump._
+### Added
+
+- **Search filter: `observation_type`** (§89-001, XR-002 P0). `/v1/search` and the `harness_mem_search` MCP tool now accept an `observation_type` parameter that filters results to one or more of the structured types stored on `mem_observations` (e.g. `decision`, `summary`, `context`, `document`). The REST endpoint and the TypeScript MCP tool accept a single string or a string array; the Go MCP tool accepts a single string only (mcp-go has no `oneOf` helper). Input is defensively clamped to at most 32 values of 100 characters each to keep the generated `IN (?, …)` predicate within SQLite's variable limit.
+- **Query-prefix `type:xxx` convention** (§89-001 Step 2). Callers who set `query` to `"type:decision <remaining text>"` get the same filtering as passing `observation_type: "decision"` explicitly — the REST handler and the TypeScript MCP tool rewrite the query before the search runs. Only a leading `type:<token>` (regex `^\s*type:([A-Za-z0-9_.-]+)\s*`) is stripped; inline phrases such as `"our \"type:safety\" policy"` are left intact. An explicit `observation_type` parameter always wins over the prefix form.
+
+### Fixed
+
+- **`observation_type` silently ignored on Go MCP** (§89-001 Step 2 hotfix, caught by independent Codex review of §89-001). The Go MCP schema exposed `observation_type` but the `harness_mem_search` handler was not forwarding it to the REST payload, so Go callers who set the field saw no behavior change. The handler now forwards the value; Go-side coverage added via `TestHandleMemSearchObservationType` and `TestHandleMemSearchObservationTypeOmitted`.
 
 ## [0.13.0] - 2026-04-18
 

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,7 +7,14 @@
 
 ## [Unreleased]
 
-_未リリースの変更はまだありません。新しいユーザー向け変更は次のバージョンバンプ前にここへ積みます。_
+### 追加
+
+- **検索フィルタ `observation_type`** (§89-001, XR-002 P0). `/v1/search` と `harness_mem_search` MCP ツールに `observation_type` パラメータを追加。`mem_observations` に保存される構造化タイプ（`decision` / `summary` / `context` / `document` など）で結果を絞り込めます。REST エンドポイントと TypeScript MCP は string / string[] を受け、Go MCP は単一 string のみ（mcp-go に `oneOf` ヘルパーが無いため）。入力は SQLite の変数上限に達しないよう最大 32 件 × 各 100 文字に防御的にクランプされます。
+- **`type:xxx` クエリプレフィクス**（§89-001 Step 2）。`query="type:decision 残りの文"` のように書くと、`observation_type="decision"` を明示的に渡したのと同じフィルタが効きます。REST ハンドラと TypeScript MCP が検索実行前に query を書き換えます。先頭の `type:<トークン>`（正規表現 `^\s*type:([A-Za-z0-9_.-]+)\s*`）だけが対象で、`"our \"type:safety\" policy"` のような本文中の引用語は影響を受けません。直接の `observation_type` パラメータは常にプレフィクス形式より優先します。
+
+### 修正
+
+- **Go MCP で `observation_type` が無視されていた問題**（§89-001 Step 2 ホットフィックス、独立 Codex レビューで検出）。Go MCP の schema には `observation_type` が公開されていたものの、`harness_mem_search` ハンドラが REST ペイロードへ転送していなかったため、Go クライアントからの指定が機能していませんでした。ハンドラで転送するよう修正し、`TestHandleMemSearchObservationType` / `TestHandleMemSearchObservationTypeOmitted` でカバレッジを追加しました。
 
 ## [0.11.0] - 2026-04-10
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -727,6 +727,19 @@ paths:
                   enum: [index, context, full]
                   default: context
                   description: "§78-E03: Progressive disclosure level. index=id+title+score only (lightest). context=+snippet(120 chars)+meta (default). full=+complete content+raw_text+score breakdown. meta.token_estimate indicates approximate token cost."
+                observation_type:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                  description: |
+                    §89-001 (XR-002 P0): Filter by observation_type. Accepts a single string
+                    (e.g. "decision") or an array (e.g. ["decision", "summary"]) and AND-combines
+                    with every other filter (project, scope, memory_type, branch, etc.).
+                    The historical query-prefix convention is also honored — `query="type:decision fix"`
+                    is rewritten to `query="fix"` + `observation_type="decision"` before the
+                    search runs. Direct parameter wins over the prefix.
       responses:
         "200":
           description: Search results

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -730,9 +730,12 @@ paths:
                 observation_type:
                   oneOf:
                     - type: string
+                      maxLength: 100
                     - type: array
+                      maxItems: 32
                       items:
                         type: string
+                        maxLength: 100
                   description: |
                     §89-001 (XR-002 P0): Filter by observation_type. Accepts a single string
                     (e.g. "decision") or an array (e.g. ["decision", "summary"]) and AND-combines
@@ -740,6 +743,10 @@ paths:
                     The historical query-prefix convention is also honored — `query="type:decision fix"`
                     is rewritten to `query="fix"` + `observation_type="decision"` before the
                     search runs. Direct parameter wins over the prefix.
+                    Input is defensively clamped to the documented limits (maxItems=32,
+                    maxLength=100) to keep the generated SQL predicate within SQLite's
+                    variable-count ceiling. Callers who exceed the limit will see the
+                    excess silently dropped; prefer sending multiple requests instead.
       responses:
         "200":
           description: Search results

--- a/mcp-server-go/internal/tools/memory.go
+++ b/mcp-server-go/internal/tools/memory.go
@@ -342,6 +342,11 @@ func handleMemoryToolInner(_ context.Context, name string, args map[string]any) 
 			"limit":           optNum(args, "limit"),
 			"include_private": argBool(args, "include_private", false),
 			"sort_by":         sortByVal,
+			// §89-001 (XR-002 P0): Forward observation_type to the REST layer.
+			// Go MCP schema exposes this as a single string (mcp-go has no oneOf
+			// helper); the REST handler also accepts string[] and the `type:xxx`
+			// query-prefix form, both of which Go callers can reach indirectly.
+			"observation_type": optStr(args, "observation_type"),
 		})
 		if err != nil {
 			return classifyError(err)

--- a/mcp-server-go/internal/tools/memory_defs.go
+++ b/mcp-server-go/internal/tools/memory_defs.go
@@ -22,6 +22,11 @@ var memToolSearch = mcp.NewTool("harness_mem_search",
 	mcp.WithNumber("limit"),
 	mcp.WithBoolean("include_private"),
 	mcp.WithString("sort_by", mcp.Description("Sort order: relevance (default), date_desc (newest first), date_asc (oldest first)"), mcp.Enum("relevance", "date_desc", "date_asc")),
+	// §89-001 (XR-002 P0): observation_type filter.
+	// Go MCP accepts a single string here; TS MCP additionally accepts string[].
+	// The `type:xxx` query-prefix convention (query="type:decision …") is also honored
+	// by the REST handler and the TS MCP pre-parser, so single-value parity is enough.
+	mcp.WithString("observation_type", mcp.Description("§89-001 (XR-002 P0): Filter by observation_type (e.g. \"decision\", \"summary\", \"context\", \"document\"). REST and TS MCP also accept a string[] and the `type:xxx` query-prefix form.")),
 )
 
 var memToolTimeline = mcp.NewTool("harness_mem_timeline",

--- a/mcp-server-go/internal/tools/memory_test.go
+++ b/mcp-server-go/internal/tools/memory_test.go
@@ -195,6 +195,79 @@ func TestHandleMemSearch(t *testing.T) {
 	}
 }
 
+// TestHandleMemSearchObservationType verifies that §89-001 Step 2's
+// `observation_type` parameter actually reaches the REST payload when a
+// Go MCP caller sets it. Guards against the regression flagged by the
+// independent Codex review: schema was exposed but the handler was not
+// forwarding the value, so Go MCP silently ignored the filter.
+func TestHandleMemSearchObservationType(t *testing.T) {
+	var receivedObsType any
+	var mu sync.Mutex
+	setupSharedMemServer(t, defaultMemHandler(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		mu.Lock()
+		receivedObsType = req["observation_type"]
+		mu.Unlock()
+		writeJSON(w, map[string]any{
+			"ok":    true,
+			"items": []any{},
+			"meta":  map[string]any{"count": float64(0)},
+		})
+	}))
+
+	result := handleMemoryToolInner(context.Background(), "harness_mem_search", map[string]any{
+		"query":            "release gate",
+		"observation_type": "decision",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %+v", result)
+	}
+	mu.Lock()
+	got := receivedObsType
+	mu.Unlock()
+	if got != "decision" {
+		t.Fatalf("REST payload observation_type = %v, want \"decision\"", got)
+	}
+}
+
+// TestHandleMemSearchObservationTypeOmitted verifies that callers who
+// don't set observation_type still reach the REST layer in a
+// pre-§89-001-compatible shape (the field is present as nil, which the
+// server normalizes to undefined — the REST handler already has
+// coverage for the nil branch via fallback to the query-prefix parser).
+func TestHandleMemSearchObservationTypeOmitted(t *testing.T) {
+	var receivedObsType any
+	var sawField bool
+	var mu sync.Mutex
+	setupSharedMemServer(t, defaultMemHandler(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		mu.Lock()
+		receivedObsType, sawField = req["observation_type"], func() bool { _, ok := req["observation_type"]; return ok }()
+		mu.Unlock()
+		writeJSON(w, map[string]any{"ok": true, "items": []any{}, "meta": map[string]any{"count": float64(0)}})
+	}))
+
+	result := handleMemoryToolInner(context.Background(), "harness_mem_search", map[string]any{
+		"query": "release gate",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %+v", result)
+	}
+	mu.Lock()
+	got, present := receivedObsType, sawField
+	mu.Unlock()
+	// Field presence with nil value is acceptable — the REST normalizer
+	// treats both missing and null as "no filter". What matters is that
+	// an unintended string (e.g. "") is NOT sent.
+	if present && got != nil {
+		t.Fatalf("observation_type forwarded unexpectedly: got %v (type %T)", got, got)
+	}
+}
+
 // TestHandleMemHealth verifies harness_mem_health returns a success result.
 func TestHandleMemHealth(t *testing.T) {
 	setupSharedMemServer(t, defaultMemHandler(func(w http.ResponseWriter, r *http.Request) {

--- a/mcp-server-go/testdata/expected_tools.json
+++ b/mcp-server-go/testdata/expected_tools.json
@@ -1056,6 +1056,10 @@
         "limit": {
           "type": "number"
         },
+        "observation_type": {
+          "description": "§89-001 (XR-002 P0): Filter by observation_type (e.g. \"decision\", \"summary\", \"context\", \"document\"). REST and TS MCP also accept a string[] and the `type:xxx` query-prefix form.",
+          "type": "string"
+        },
         "project": {
           "type": "string"
         },

--- a/mcp-server/src/tools/memory.ts
+++ b/mcp-server/src/tools/memory.ts
@@ -318,6 +318,13 @@ export const memoryTools: Tool[] = [
           enum: ["index", "context", "full"],
           description: "§78-E03: Progressive disclosure level. index=id+title+score only (lightest). context=+snippet(120 chars)+meta (default, preserves existing behavior). full=+complete content+raw_text+score breakdown. meta.token_estimate shows approximate token cost.",
         },
+        observation_type: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+          description: "§89-001 (XR-002 P0): Filter by observation_type (e.g. \"decision\", \"summary\", \"context\", \"document\"). Single value or array. Also honors the `type:xxx` query-prefix convention — `query=\"type:decision …\"` is rewritten to `observation_type=\"decision\"` + the remaining query.",
+        },
       },
       required: ["query"],
     },
@@ -859,9 +866,43 @@ async function handleMemoryToolInner(
       }
 
       case "harness_mem_search": {
-        const query = toStringOrUndefined(input.query);
-        if (!query) {
+        const rawQuery = toStringOrUndefined(input.query);
+        if (!rawQuery) {
           return errorResult("query is required");
+        }
+
+        // §89-001 (XR-002 P0): observation_type direct parameter + `type:xxx` query prefix.
+        // Accepts a single string, a string[], or falls through to prefix parsing
+        // (e.g. `query="type:decision fix release gate"` → observation_type="decision",
+        //  query="fix release gate"). Direct parameter always wins over prefix.
+        const rawObservationType = input.observation_type;
+        let observationType: string | string[] | undefined;
+        if (typeof rawObservationType === "string" && rawObservationType.trim().length > 0) {
+          observationType = rawObservationType.trim();
+        } else if (Array.isArray(rawObservationType)) {
+          const cleaned = rawObservationType
+            .filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+            .map((t) => t.trim());
+          observationType = cleaned.length > 0 ? cleaned : undefined;
+        }
+
+        let query = rawQuery;
+        if (observationType === undefined) {
+          // Prefix parser: only the very first token is treated as a type filter.
+          // Anchored match so ordinary text like `"type:safety" is our convention`
+          // does not get stripped.
+          const prefixMatch = query.match(/^\s*type:([A-Za-z0-9_.-]+)\s*/);
+          if (prefixMatch) {
+            observationType = prefixMatch[1];
+            query = query.slice(prefixMatch[0].length).trim();
+            if (!query) {
+              // `type:decision` with no remaining query text. Preserve the raw query
+              // so downstream validation still accepts it, but the filter takes
+              // effect by way of observation_type. The core search treats this as
+              // "match anything of this type".
+              query = rawQuery.trim();
+            }
+          }
         }
 
         const sortBy = toStringOrUndefined(input.sort_by);
@@ -900,6 +941,8 @@ async function handleMemoryToolInner(
           branch: toStringOrUndefined(input.branch),
           // S78-C03: Multi-hop reasoning depth (0 = disabled, backward compatible)
           graph_depth: toNumberOrUndefined(input.graph_depth),
+          // §89-001 (XR-002 P0): observation_type filter (direct + prefix parsed)
+          observation_type: observationType,
         });
 
         // §78-E03: apply progressive disclosure + inject token_estimate into meta

--- a/mcp-server/src/tools/memory.ts
+++ b/mcp-server/src/tools/memory.ts
@@ -320,10 +320,10 @@ export const memoryTools: Tool[] = [
         },
         observation_type: {
           oneOf: [
-            { type: "string" },
-            { type: "array", items: { type: "string" } },
+            { type: "string", maxLength: 100 },
+            { type: "array", maxItems: 32, items: { type: "string", maxLength: 100 } },
           ],
-          description: "§89-001 (XR-002 P0): Filter by observation_type (e.g. \"decision\", \"summary\", \"context\", \"document\"). Single value or array. Also honors the `type:xxx` query-prefix convention — `query=\"type:decision …\"` is rewritten to `observation_type=\"decision\"` + the remaining query.",
+          description: "§89-001 (XR-002 P0): Filter by observation_type (e.g. \"decision\", \"summary\", \"context\", \"document\"). Single value or array (maxItems=32, each maxLength=100). Input exceeding the limit is silently clamped server-side to stay within SQLite's variable ceiling; send multiple requests if you need more. Also honors the `type:xxx` query-prefix convention — `query=\"type:decision …\"` is rewritten to `observation_type=\"decision\"` + the remaining query.",
         },
       },
       required: ["query"],

--- a/memory-server/src/core/observation-store.ts
+++ b/memory-server/src/core/observation-store.ts
@@ -1371,12 +1371,23 @@ export class ObservationStore {
     // §89-001 (XR-002 P0): observation_type フィルタ
     // decision / summary / context / document など、スキーマ上の free-form 文字列で絞り込む。
     // memory_type とは直交軸 (episodic/semantic/procedural ≠ decision/summary/...) で、AND 結合される。
+    //
+    // Defensive clamp: even though the REST handler already bounds the input,
+    // applyCommonFilters is callable from other code paths (e.g. ingest-side
+    // dedup lookups in future work), so we re-enforce the same ceiling here
+    // to keep the generated SQL predictable under any caller.
     if (filters.observation_type !== undefined) {
-      const obsTypes = Array.isArray(filters.observation_type)
-        ? filters.observation_type.filter((t) => typeof t === "string" && t.length > 0)
-        : (typeof filters.observation_type === "string" && filters.observation_type.length > 0
-            ? [filters.observation_type]
-            : []);
+      const MAX_OBS_TYPES = 32;
+      const MAX_OBS_TYPE_LEN = 100;
+      const obsTypes = (
+        Array.isArray(filters.observation_type)
+          ? filters.observation_type.filter((t) => typeof t === "string" && t.length > 0)
+          : (typeof filters.observation_type === "string" && filters.observation_type.length > 0
+              ? [filters.observation_type]
+              : [])
+      )
+        .map((t) => t.slice(0, MAX_OBS_TYPE_LEN))
+        .slice(0, MAX_OBS_TYPES);
       if (obsTypes.length === 1) {
         nextSql += ` AND ${alias}.observation_type = ?`;
         params.push(obsTypes[0]);

--- a/memory-server/src/core/observation-store.ts
+++ b/memory-server/src/core/observation-store.ts
@@ -1379,14 +1379,18 @@ export class ObservationStore {
     if (filters.observation_type !== undefined) {
       const MAX_OBS_TYPES = 32;
       const MAX_OBS_TYPE_LEN = 100;
+      // Trim + length-clamp mirrors the REST handler so direct core callers
+      // (e.g. internal workflows that construct SearchRequest without going
+      // through server.ts) cannot smuggle surrounding whitespace that would
+      // never match the DB value.
       const obsTypes = (
         Array.isArray(filters.observation_type)
-          ? filters.observation_type.filter((t) => typeof t === "string" && t.length > 0)
-          : (typeof filters.observation_type === "string" && filters.observation_type.length > 0
+          ? filters.observation_type.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+          : (typeof filters.observation_type === "string" && filters.observation_type.trim().length > 0
               ? [filters.observation_type]
               : [])
       )
-        .map((t) => t.slice(0, MAX_OBS_TYPE_LEN))
+        .map((t) => t.trim().slice(0, MAX_OBS_TYPE_LEN))
         .slice(0, MAX_OBS_TYPES);
       if (obsTypes.length === 1) {
         nextSql += ` AND ${alias}.observation_type = ?`;

--- a/memory-server/src/server.ts
+++ b/memory-server/src/server.ts
@@ -693,11 +693,21 @@ export function startHarnessMemServer(core: HarnessMemCore, config: Config) {
             //   2. body.query の先頭に `type:xxx ` prefix がある場合（Step 2 で pre-parse 済み）
             //   3. どちらも無ければ undefined（後方互換）
             observation_type: (() => {
+              // §89-001 hardening: clamp to defensive bounds so oversized
+              // arrays can never blow up SQLite's variable limit or explode
+              // the generated `IN (?, ?, …)` placeholder count.
+              const MAX_OBS_TYPES = 32;
+              const MAX_OBS_TYPE_LEN = 100;
               const raw = body.observation_type;
-              if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
-              if (Array.isArray(raw)) {
-                const cleaned = raw.filter((t): t is string => typeof t === "string" && t.trim().length > 0).map((t) => t.trim());
-                return cleaned.length > 0 ? cleaned : undefined;
+              if (typeof raw === "string") {
+                const trimmed = raw.trim().slice(0, MAX_OBS_TYPE_LEN);
+                if (trimmed.length > 0) return trimmed;
+              } else if (Array.isArray(raw)) {
+                const cleaned = raw
+                  .filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+                  .map((t) => t.trim().slice(0, MAX_OBS_TYPE_LEN))
+                  .slice(0, MAX_OBS_TYPES);
+                if (cleaned.length > 0) return cleaned;
               }
               return parsedObservationTypeFromPrefix;
             })(),

--- a/memory-server/src/server.ts
+++ b/memory-server/src/server.ts
@@ -602,9 +602,26 @@ export function startHarnessMemServer(core: HarnessMemCore, config: Config) {
           if (!searchValidation.valid) {
             return badRequest(searchValidation.errors.join("; "));
           }
-          const query = typeof body.query === "string" ? body.query : "";
-          if (!query) {
+          const rawQueryInput = typeof body.query === "string" ? body.query : "";
+          if (!rawQueryInput) {
             return badRequest("query is required");
+          }
+
+          // §89-001 (XR-002 P0): `type:xxx` query-prefix pre-parser.
+          // Rewrite `query="type:decision remaining text"` into
+          // `query="remaining text"` + `observation_type="decision"` so REST
+          // callers who use the historical prefix convention get the same
+          // filtering semantics as the explicit `observation_type` parameter.
+          // The direct `observation_type` body field, if present, always wins.
+          let query = rawQueryInput;
+          let parsedObservationTypeFromPrefix: string | undefined;
+          if (body.observation_type === undefined || body.observation_type === null) {
+            const prefixMatch = query.match(/^\s*type:([A-Za-z0-9_.-]+)\s*/);
+            if (prefixMatch) {
+              parsedObservationTypeFromPrefix = prefixMatch[1];
+              const remainder = query.slice(prefixMatch[0].length).trim();
+              query = remainder.length > 0 ? remainder : rawQueryInput.trim();
+            }
           }
 
           const questionKind = typeof body.question_kind === "string" ? body.question_kind : undefined;
@@ -670,8 +687,11 @@ export function startHarnessMemServer(core: HarnessMemCore, config: Config) {
             include_superseded: typeof body.include_superseded === "boolean" ? body.include_superseded : undefined,
             // S78-C03: Multi-hop reasoning — entity graph 経由の関連観察追加取得
             graph_depth: typeof body.graph_depth === "number" ? body.graph_depth : undefined,
-            // §89-001 (XR-002 P0): observation_type フィルタ
-            // string または string[] を受け付け、空配列・非文字列要素は無視する。
+            // §89-001 (XR-002 P0): observation_type フィルタ。
+            // 優先順位:
+            //   1. body.observation_type 直接指定（string または string[]）
+            //   2. body.query の先頭に `type:xxx ` prefix がある場合（Step 2 で pre-parse 済み）
+            //   3. どちらも無ければ undefined（後方互換）
             observation_type: (() => {
               const raw = body.observation_type;
               if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
@@ -679,7 +699,7 @@ export function startHarnessMemServer(core: HarnessMemCore, config: Config) {
                 const cleaned = raw.filter((t): t is string => typeof t === "string" && t.trim().length > 0).map((t) => t.trim());
                 return cleaned.length > 0 ? cleaned : undefined;
               }
-              return undefined;
+              return parsedObservationTypeFromPrefix;
             })(),
           };
           return jsonResponse(await core.searchPrepared(req));


### PR DESCRIPTION
## Summary

Step 2 of 3 for **§89-001** (parent: `harness-governance-private` XR-002 P0). Extends the Step 1 core filter so every documented call surface understands `observation_type` end-to-end, and preserves the historical `type:xxx` query-prefix convention that already appears in deployed clients (2026-04-18 SSOT review confirmed it is in active use).

### What changes

**MCP surface (schema + handler)**
- `mcp-server/src/tools/memory.ts` — `harness_mem_search` gains `observation_type` (oneOf: string or string[]). Handler parses `^\s*type:(\S+)\s*` from the query when the direct parameter is absent and rewrites query + observation_type. Direct parameter wins over the prefix.
- `mcp-server-go/internal/tools/memory_defs.go` — `memToolSearch` registers `observation_type` as `WithString` (mcp-go has no `oneOf` helper). Description points Go callers to REST / TS MCP for array form.
- `mcp-server-go/testdata/expected_tools.json` — snapshot regenerated to include `observation_type` alphabetically between `limit` and `project`. `schema_parity_test.go` passes.

**REST surface (prefix parser)**
- `memory-server/src/server.ts` — `/v1/search` body parser extracts the same prefix as a fallback when `body.observation_type` is absent, and forwards it into the `SearchRequest` introduced in Step 1.

**Contract documentation**
- `docs/openapi.yaml` — `POST /v1/search` request body gains `observation_type` (oneOf: string or array of strings) with the precedence rule and prefix-form equivalence documented.

### Design choices worth calling out

- **Prefix pattern anchored at the start of the query** (`^\s*type:[A-Za-z0-9_.-]+\s*`). This means an inline reference like `our "type:safety" policy` is **not** stripped — only a leading `type:decision fix release gate` form is rewritten.
- **Direct parameter wins over the prefix.** If a client sends both `observation_type="summary"` and `query="type:decision …"`, the direct parameter stays, and the query keeps the prefix text for lexical matching.
- **Go MCP accepts single string only.** mcp-go has no helper for `oneOf: [string, array]`. Single value + the prefix form are sufficient for the 2026-04-18 call pattern that triggered the review; array form remains available on REST and TS MCP.

### Out of scope

- Integration test coverage ships in **Step 3** (`feat/s89-001-search-observation-type-tests`, base = this PR).

## Test plan

- [ ] `cd mcp-server-go && go test ./...` — `schema_parity_test.go` passes with the new snapshot
- [ ] `bun run typecheck` — no new diagnostics from `memory.ts` or `server.ts`
- [ ] `curl -X POST /v1/search -d '{"query":"type:decision release gate"}'` returns only `observation_type=decision` rows (automated coverage lands in Step 3)
- [ ] `curl -X POST /v1/search -d '{"query":"release gate","observation_type":"decision"}'` same result via direct param
- [ ] `curl -X POST /v1/search -d '{"query":"release gate"}'` unchanged pre-§89 behavior

## Parent tracking

- `harness-governance-private/XR-Registry.md` **XR-002** (open)
- Depends on: #63 (Step 1 core + REST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)