### PR TITLE
Release v0.14.0 (retry): align plugin.json + marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode, Gemini CLI)",
-  "version": "0.13.0",
+  "version": "0.14.0",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",


### PR DESCRIPTION
## Context

初回 v0.14.0 release (PR #71, merged as `0134b06`) が `release.yml` workflow で failure。原因は `tests/marketplace-schema.test.ts` の version-consistency gate:

- `.claude-plugin/plugin.json` が `0.13.0` のまま
- `.claude-plugin/marketplace.json` の metadata.version と plugins[0].version が `0.13.0` のまま
- 結果: publish-npm job が behavior gate で停止 → npm 未公開

## What this PR fixes

3 箇所の version 文字列を `0.14.0` に揃えて、上記 gate を通過させる。

| File | Field | 0.13.0 → 0.14.0 |
|---|---|---|
| `.claude-plugin/plugin.json` | `.version` | ✅ |
| `.claude-plugin/marketplace.json` | `.metadata.version` | ✅ |
| `.claude-plugin/marketplace.json` | `.plugins[0].version` | ✅ |

## Validation

`bun test tests/marketplace-schema.test.ts` → **22 pass / 0 fail**

## Release flow after merge

1. tag `v0.14.0` (削除済) を新 HEAD に再作成 → push
2. `gh release create v0.14.0` で GitHub Release 再公開
3. `release.yml` workflow が今度は完走 → npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)