### PR TITLE
Release v0.14.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode, Gemini CLI)",
-  "version": "0.14.0",
+  "version": "0.14.1",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-04-21
+
 ### Fixed
 
 - **Unified DB path — remove implicit `CLAUDE_PLUGIN_DATA` → `HARNESS_MEM_DB_PATH` promotion** (§94). `scripts/hook-handlers/lib/hook-common.sh` previously set `export HARNESS_MEM_DB_PATH="${CLAUDE_PLUGIN_DATA}/harness-mem.db"` whenever `CLAUDE_PLUGIN_DATA` was set and `HARNESS_MEM_DB_PATH` was unset. Because Claude Code injects a *different* `CLAUDE_PLUGIN_DATA` per plugin slot (`claude-code-harness-inline` / `codex-openai-codex` / marketplace variants), every installed plugin slot ended up with its own `harness-mem.db`, fragmenting observation history across 4 databases in affected environments (root-cause discovery driven by the §93 doctor WARN). The promotion is now removed; `HARNESS_MEM_DB_PATH` precedence is strictly: (1) explicit env (respected verbatim — backward-compatible), (2) `HARNESS_MEM_HOME/harness-mem.db`, (3) default `~/.harness-mem/harness-mem.db`. `PLUGIN_DATA_DIR` is still exported for non-DB plugin-slot state, but it no longer participates in DB path resolution. A one-shot stderr warning fires when `CLAUDE_PLUGIN_DATA` is set without an explicit `HARNESS_MEM_DB_PATH`, so operators coming from ≤ v0.14.0 see that their data is now consolidated (suppressible via `HARNESS_MEM_SUPPRESS_PLUGIN_DATA_WARN=1`). Users who set `HARNESS_MEM_DB_PATH` explicitly are not affected. Data still living in previously-created plugin-scoped DBs is not auto-merged — the §93 doctor WARN surfaces them and operators merge manually. New test: `tests/hook-common-db-path-unification.test.sh` (8 assertions, fixture-based).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Release v0.14.1

**Patch release: fix DB path splitting across plugin slots**

### Fixed (§94, the whole reason for this patch)

- **Remove implicit `CLAUDE_PLUGIN_DATA` → `HARNESS_MEM_DB_PATH` promotion** — `scripts/hook-handlers/lib/hook-common.sh` no longer auto-sets `HARNESS_MEM_DB_PATH` from `CLAUDE_PLUGIN_DATA`. This fixes environments where Claude Code created a separate `harness-mem.db` per installed plugin slot (inline / codex / marketplace), fragmenting observation history.
- **Backward-compatible**: users who set `HARNESS_MEM_DB_PATH` explicitly are unaffected.
- **Warn on legacy config**: emits a one-shot stderr warning when `CLAUDE_PLUGIN_DATA` is set without an explicit `HARNESS_MEM_DB_PATH` (suppress with `HARNESS_MEM_SUPPRESS_PLUGIN_DATA_WARN=1`).
- Existing plugin-scoped DBs are **not auto-migrated** — the §93 doctor WARN surfaces them so operators can consolidate manually.

### Added (§93, landed on main already, included in release notes for completeness)

- **`harness-mem doctor`: multiple `harness-mem.db` detection** — doctor now WARNs when additional DBs exist beyond the current daemon's DB.

### Version sync

- package.json / plugin.json / marketplace.json (metadata + plugin entry) → all `0.14.1`
- tests/marketplace-schema.test.ts → 22 pass / 0 fail

### Merge strategy

**rebase-and-merge** to keep release commit hash deterministic for tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)