### PR TITLE
refactor(s108-014): warn log on relation batch failure + config-resolved temporal graph flag

### DIFF
--- a/memory-server/src/core/core-utils.ts
+++ b/memory-server/src/core/core-utils.ts
@@ -1304,12 +1304,21 @@ export function getConfig(): Config {
       ? reindexBatchCandidate
       : 100;
 
+  // S108-014: temporal graph signal PoC opt-in (default OFF).
+  // Resolved once at startup so the search hot path reads from Config
+  // (consistent with partialFinalizeEnabled / reindexVectorsEnabled).
+  const temporalGraphRaw = (process.env.HARNESS_MEM_TEMPORAL_GRAPH || "").trim().toLowerCase();
+  const temporalGraphEnabled = temporalGraphRaw !== ""
+    ? (temporalGraphRaw === "true" || temporalGraphRaw === "1")
+    : userConfig.temporalGraphEnabled === true;
+
   return {
     partialFinalizeEnabled,
     partialFinalizeIntervalMs,
     reindexVectorsEnabled,
     reindexVectorsIntervalMs,
     reindexVectorsBatchSize,
+    temporalGraphEnabled,
     dbPath,
     bindHost,
     bindPort: Number.isFinite(bindPort) ? bindPort : DEFAULT_BIND_PORT,

--- a/memory-server/src/core/observation-store.ts
+++ b/memory-server/src/core/observation-store.ts
@@ -21,7 +21,6 @@ import { getDecayTier, getDecayMultiplier } from "./adaptive-decay.js";
 import { expandObservationsViaGraph, computeQueryEntityProximity } from "./graph-reasoner.js";
 import {
   computeTemporalGraphSignal,
-  temporalGraphEnabled,
   DEFAULT_TEMPORAL_GRAPH_WEIGHT,
 } from "./temporal-graph-signal.js";
 import { routeQuery, type AnswerHints, type RouteDecision, type TemporalAnchor } from "../retrieval/router";
@@ -3485,11 +3484,11 @@ export class ObservationStore {
     }
 
     // S108-014: temporal-graph signal (default-off PoC)
-    // Enabled with HARNESS_MEM_TEMPORAL_GRAPH=1. Computes a small additive
-    // bonus from mem_relations.kind / strength / valid_from-to / invalidated_at
-    // / supersedes. When the env flag is off, the map stays empty and the
-    // blender path is a no-op (existing default ranking is preserved bit-for-bit).
-    const temporalGraphOn = temporalGraphEnabled();
+    // Resolved at daemon startup (core-utils.ts) and exposed via Config —
+    // matches the partialFinalizeEnabled / reindexVectorsEnabled pattern,
+    // and avoids reading process.env on the search hot path. When the flag
+    // is off, the map stays empty and the blender path is a bit-exact no-op.
+    const temporalGraphOn = this.deps.config.temporalGraphEnabled === true;
     const temporalGraphScores = new Map<string, number>();
     if (temporalGraphOn && candidateIds.size > 0) {
       const rawSignal = computeTemporalGraphSignal(this.deps.db, [...candidateIds]);

--- a/memory-server/src/core/temporal-graph-signal.ts
+++ b/memory-server/src/core/temporal-graph-signal.ts
@@ -125,9 +125,15 @@ export function computeTemporalGraphSignal(
            WHERE observation_id IN (${placeholders})`,
         )
         .all(...batch) as typeof rows;
-    } catch {
-      // Best-effort signal: if the table is missing or the query fails for
-      // any reason, return a no-op map — never break the search path.
+    } catch (err) {
+      // Best-effort signal: never break the search path. We log a single
+      // WARN per failing batch so an operator can spot a misconfigured
+      // env-gate or a missing table — and so a partial map (some batches
+      // populated, some skipped) is not silently invisible.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[temporal-graph-signal] WARN: relation lookup failed for batch (${batch.length} candidates) — skipping: ${msg}`,
+      );
       continue;
     }
 

--- a/memory-server/src/core/types.ts
+++ b/memory-server/src/core/types.ts
@@ -546,4 +546,8 @@ export interface Config {
   reindexVectorsIntervalMs?: number;
   /** S89-003: 1 tick あたりの reindex 件数上限 (既定 100) */
   reindexVectorsBatchSize?: number;
+  /** S108-014: temporal graph signal PoC を有効にするか (既定 false = opt-in)。
+   *  daemon 起動時に env / userConfig から一度だけ解決し、search hot path では
+   *  config 経由で読む（per-search の process.env 読み取りを廃止）。 */
+  temporalGraphEnabled?: boolean;
 }


### PR DESCRIPTION
## Summary

PR #96 のレビューで指摘された軽微な品質改善 2 点を片付ける follow-up。

1. **`temporal-graph-signal.ts`**: relation lookup batch が失敗したときに `console.warn` を 1 回出すようにした。partial map で degrade する fail-safe 挙動はそのままだが、operator が breadcrumb で気付ける。
2. **config 統一**: `HARNESS_MEM_TEMPORAL_GRAPH` を daemon 起動時に一度だけ解決し `Config.temporalGraphEnabled` に格納。search hot path は `this.deps.config.temporalGraphEnabled === true` を読むようになり、`partialFinalizeEnabled` / `reindexVectorsEnabled` と pattern が揃った。`temporalGraphEnabled(env)` helper は pure parser として残置 (unit test 用)。

## Test plan

- [x] `bun test memory-server/tests/unit/temporal-graph-signal.test.ts` — 17/17 pass (graceful-failure case で WARN 確認)
- [x] `bun test memory-server/tests/unit/reindex-vectors-scheduler.test.ts` — 8/8 pass
- [x] `bun test memory-server/tests/core-split/` — 138/138 pass (回帰なし)
- [x] `bun test scripts/s108-temporal-graph-ab-gate.test.ts` — 7/7 pass

## Behavioral diff

- **default-off path**: 完全に変化なし (env unset → config false → blender が `temporalGraphAdj=0`)
- **opt-in path**: 起動時に env 解決 → config に格納 → search hot path で `process.env` を読まなくなる
- **failure path**: 既存の silent partial-map → 同じだが WARN が出る (search 結果には影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)