### PR TITLE
Fix Cursor hook ingest retry and backfill bounds

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -275,6 +275,54 @@ team_validation_mode: subagent（Product / Architecture / Security / QA / Skepti
 
 ---
 
+## §134 Cursor Hook Spool Ingest Gap Investigation — cc:完了 [local]
+
+策定日: 2026-05-28
+分類: Cursor ingest / dogfood incident investigation — owner は `harness-mem`。§132 の Cursor Hooks capture が local spool には記録されるが、検索可能な `mem_events` / `mem_observations` に反映されない現象を対象にする。
+仕様正本: `Spec.md` の **Cursor Conversation Capture**。保存失敗は fail-open だが、daemon ingest が spool offset を進める場合は DB 反映または明示的な skip reason が観測できること。
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| S134-001 | **root cause evidence** `[tdd:skip:investigation]` — `~/.harness-mem/adapters/cursor/events.jsonl`、`mem_ingest_offsets`、`mem_events` / `mem_observations`、ingest code path を突き合わせる | 完了: 対象 session `dd9d71c4-81be-4cf6-98ba-e7c02b0adc4b` は spool に 248 行あるが DB は 0 行。対象 `beforeSubmitPrompt` を rollback transaction で再実行すると parser は `user_prompt` を返す一方、`recordEvent` が `write embedding is unavailable: local ONNX model ruri-v3-30m is still warming up` で `ok:false`。`ingestCursorHooksEvents()` は `result.ok` を count しないだけで `parsedChunk.consumedBytes` ぶん offset を進めるため、embedding warmup 中の non-checkpoint hook events が DB 未反映のまま消費済みになる | §132, §133 | cc:完了 [local] |
+
+---
+
+## §135 Cursor Hook Ingest Retry Offset Fix — cc:完了 [local]
+
+策定日: 2026-05-28
+分類: Cursor ingest / reliability fix — owner は `harness-mem`。§134 で特定した recordEvent 失敗時の offset 過進行を、既存 Cursor ingest contract を壊さず最小差分で修正する。
+仕様正本: `Spec.md` の **Cursor Conversation Capture**。保存失敗は fail-open だが、DB 未反映の event line は消費済みにせず次回 ingest で再試行できること。
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| S135-001 | **Cursor hook record failure retry offset** `[tdd:required]` — `recordEvent()` 失敗時に失敗行の `lineOffset` で offset を止め、summary に失敗理由を返す | 完了: 失敗前のイベントは記録済みとして offset 前進、失敗イベント以降は次回再試行。summary / meta に `hooks_events_failed`, `retry_offset`, `last_record_error` を追加。Cursor ingest unit/integration と typecheck が PASS | §134 | cc:完了 [local] |
+
+---
+
+## §136 Cursor Hook Ingest Bounded Backfill — cc:完了 [local]
+
+策定日: 2026-05-28
+分類: Cursor ingest / runtime stability — owner は `harness-mem`。§135 検証中に、過去 session offset へ巻き戻した場合に 1 request で大量 hook events を同期処理し、daemon main thread が SQLite/vector writes で `/health/ready` を長時間返せなくなる現象を対象にする。
+仕様正本: `Spec.md` の **Cursor Conversation Capture**。保存失敗は fail-open、かつ backfill は daemon readiness を長時間奪わない bounded work として扱う。
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| S136-001 | **bounded cursor hook ingest batch** `[tdd:required]` — Cursor hook ingest を 1 run あたり bounded 件数に制限し、未処理分は `retry_offset` から次回再開する | 完了: 1回50件まで処理し、残りは `hooks_events_deferred` / `retry_offset` として返す。対象 session backfill 実測で ingest 51.8ms、ready 0.8ms、offset は50件後に前進。focused integration test PASS | §135 | cc:完了 [local] |
+
+---
+
+## §137 Checkpoint Record Main-thread Stall — cc:完了 [local]
+
+策定日: 2026-05-28
+分類: checkpoint record / runtime stability — owner は `harness-mem`。Cursor ingest 修正検証中に `harness_mem_record_checkpoint` が daemon main thread を長時間塞ぎ、`/health/ready` が timeout する現象を対象にする。
+仕様正本: `Spec.md` の local-first memory write / bounded daemon responsiveness。checkpoint write は fail-open ではなく durability を返すが、derived materialization / heavy indexing は request path と daemon main thread を塞がないこと。
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| S137-001 | **checkpoint stall root cause and fix** `[tdd:required]` — `recordCheckpointQueued` / child offload / materialization scheduling のどこで main thread が塞がるか runtime log で特定し、証拠に基づいて最小修正する | 完了: HTTP と MCP の両経路で runtime log を取得し、`recordCheckpointQueued` は child offload、checkpoint child は 0.8-1.0s で exit 0、derived materialization は child process で 95-161ms、直後の `/health/ready` は 0.2-7.5ms。stall は再現せず、旧 unmanaged daemon 残存による環境要因と判断。追加コード修正は不要、instrumentation は削除済み | §127-005, §136 | cc:完了 [local] |
+
+---
+
 ## §78 World-class Retrieval & Memory Architecture — cc:WIP (Phase A–E 全タスクが landed、残は follow-up: §78-B02b tests / §78-C02b NLP upgrade / §78-D01b tests / §78-E02b branch merge workflow)
 
 策定日: 2026-04-13

--- a/memory-server/src/core/ingest-coordinator.ts
+++ b/memory-server/src/core/ingest-coordinator.ts
@@ -81,6 +81,8 @@ function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+const MAX_CURSOR_HOOK_EVENTS_PER_INGEST = 50;
+
 // ---------------------------------------------------------------------------
 // ファイルリスト系ヘルパー（core から移動）
 // ---------------------------------------------------------------------------
@@ -328,14 +330,20 @@ function mergeOpencodeIngestSummary(target: OpencodeIngestSummary, partial: Open
 
 interface CursorIngestSummary {
   eventsImported: number;
+  eventsFailed: number;
+  eventsDeferred: number;
   filesScanned: number;
   filesSkippedBackfill: number;
   hooksEventsImported: number;
+  retryOffset?: number;
+  lastRecordError?: string;
 }
 
 function emptyCursorIngestSummary(): CursorIngestSummary {
   return {
     eventsImported: 0,
+    eventsFailed: 0,
+    eventsDeferred: 0,
     filesScanned: 0,
     filesSkippedBackfill: 0,
     hooksEventsImported: 0,
@@ -344,9 +352,17 @@ function emptyCursorIngestSummary(): CursorIngestSummary {
 
 function mergeCursorIngestSummary(target: CursorIngestSummary, partial: CursorIngestSummary): void {
   target.eventsImported += partial.eventsImported;
+  target.eventsFailed += partial.eventsFailed;
+  target.eventsDeferred += partial.eventsDeferred;
   target.filesScanned += partial.filesScanned;
   target.filesSkippedBackfill += partial.filesSkippedBackfill;
   target.hooksEventsImported += partial.hooksEventsImported;
+  if (partial.retryOffset !== undefined) {
+    target.retryOffset = partial.retryOffset;
+  }
+  if (partial.lastRecordError) {
+    target.lastRecordError = partial.lastRecordError;
+  }
 }
 
 interface AntigravityIngestSummary {
@@ -1643,7 +1659,15 @@ export class IngestCoordinator {
     });
 
     let imported = 0;
+    let nextOffset = offset + parsedChunk.consumedBytes;
+    let processed = 0;
     for (const entry of parsedChunk.events) {
+      if (processed >= MAX_CURSOR_HOOK_EVENTS_PER_INGEST) {
+        nextOffset = Math.max(offset, entry.lineOffset);
+        summary.eventsDeferred = parsedChunk.events.length - processed;
+        summary.retryOffset = nextOffset;
+        break;
+      }
       const result = this.deps.recordEvent(
         {
           platform: "cursor",
@@ -1658,6 +1682,14 @@ export class IngestCoordinator {
         },
         { allowQueue: false }
       );
+      if (!result.ok) {
+        nextOffset = Math.max(offset, entry.lineOffset);
+        summary.eventsFailed += 1;
+        summary.retryOffset = nextOffset;
+        summary.lastRecordError = result.error || "recordEvent failed";
+        break;
+      }
+      processed += 1;
       const deduped = Boolean((result.meta as Record<string, unknown>)?.deduped);
       if (result.ok && !deduped) {
         imported += 1;
@@ -1667,8 +1699,8 @@ export class IngestCoordinator {
     summary.eventsImported += imported;
     summary.hooksEventsImported += imported;
 
-    if (parsedChunk.consumedBytes > 0) {
-      this.updateIngestOffset(sourceKey, offset + parsedChunk.consumedBytes);
+    if (nextOffset > offset) {
+      this.updateIngestOffset(sourceKey, nextOffset);
     }
 
     return summary;
@@ -1685,6 +1717,8 @@ export class IngestCoordinator {
             files_scanned: 0,
             files_skipped_backfill: 0,
             hooks_events_imported: 0,
+            hooks_events_failed: 0,
+            hooks_events_deferred: 0,
           },
         ],
         {},
@@ -1702,10 +1736,20 @@ export class IngestCoordinator {
           files_scanned: summary.filesScanned,
           files_skipped_backfill: summary.filesSkippedBackfill,
           hooks_events_imported: summary.hooksEventsImported,
+          hooks_events_failed: summary.eventsFailed,
+          hooks_events_deferred: summary.eventsDeferred,
+          retry_offset: summary.retryOffset,
+          last_record_error: summary.lastRecordError,
         },
       ],
       {},
-      { ingest_mode: "cursor_spool_v1" }
+      {
+        ingest_mode: "cursor_spool_v1",
+        hooks_events_failed: summary.eventsFailed,
+        hooks_events_deferred: summary.eventsDeferred,
+        retry_offset: summary.retryOffset,
+        last_record_error: summary.lastRecordError,
+      }
     );
   }
 

--- a/memory-server/tests/integration/ingest-cursor-hooks.test.ts
+++ b/memory-server/tests/integration/ingest-cursor-hooks.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { appendFileSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
+import { IngestCoordinator } from "../../src/core/ingest-coordinator";
 import { HarnessMemCore, type Config } from "../../src/core/harness-mem-core";
+import type { ApiResponse, EventEnvelope } from "../../src/core/types";
 import { startHarnessMemServer } from "../../src/server";
 
 function createRuntime(name: string): {
@@ -53,6 +56,258 @@ function createRuntime(name: string): {
 }
 
 describe("cursor hooks ingest integration", () => {
+  test("stops offset at failed recordEvent line and retries it on next ingest", () => {
+    const dir = mkdtempSync(join(tmpdir(), "harness-mem-cursor-hooks-retry-"));
+    const cursorEventsPath = join(dir, "cursor", "events.jsonl");
+    mkdirSync(join(dir, "cursor"), { recursive: true });
+
+    const firstLine = JSON.stringify({
+      hook_event_name: "beforeSubmitPrompt",
+      conversation_id: "cursor-retry-1",
+      workspace_roots: [join(dir, "project")],
+      prompt: "cursor hook retry first prompt",
+      timestamp: "2026-02-16T10:00:00.000Z",
+    });
+    const secondPrompt = "cursor hook retry second prompt";
+    const secondLine = JSON.stringify({
+      hook_event_name: "beforeSubmitPrompt",
+      conversation_id: "cursor-retry-1",
+      workspace_roots: [join(dir, "project")],
+      prompt: secondPrompt,
+      timestamp: "2026-02-16T10:00:01.000Z",
+    });
+    const fileContent = `${firstLine}\n${secondLine}\n`;
+    writeFileSync(cursorEventsPath, fileContent, "utf8");
+
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE mem_ingest_offsets(
+        source_key TEXT PRIMARY KEY,
+        offset INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+
+    const config: Config = {
+      dbPath: join(dir, "harness-mem.db"),
+      bindHost: "127.0.0.1",
+      bindPort: 0,
+      vectorDimension: 64,
+      captureEnabled: true,
+      retrievalEnabled: true,
+      injectionEnabled: true,
+      codexHistoryEnabled: false,
+      codexProjectRoot: dir,
+      codexSessionsRoot: join(dir, "codex-sessions"),
+      codexIngestIntervalMs: 3600000,
+      codexBackfillHours: 24,
+      cursorIngestEnabled: true,
+      cursorEventsPath,
+      cursorBackfillHours: 24,
+    };
+
+    const okResponse = (): ApiResponse => ({
+      ok: true,
+      source: "core",
+      items: [],
+      meta: {
+        count: 0,
+        latency_ms: 0,
+        sla_latency_ms: 200,
+        filters: {},
+        ranking: "test",
+      },
+    });
+    const failResponse = (): ApiResponse => ({
+      ok: false,
+      source: "core",
+      items: [],
+      meta: {
+        count: 0,
+        latency_ms: 0,
+        sla_latency_ms: 200,
+        filters: {},
+        ranking: "test",
+      },
+      error: "write embedding is unavailable: local ONNX model is still warming up",
+    });
+
+    const recorded: EventEnvelope[] = [];
+    let failSecondPrompt = true;
+    const coordinator = new IngestCoordinator({
+      db,
+      config,
+      recordEvent: (event) => {
+        recorded.push(event);
+        if (failSecondPrompt && event.payload?.prompt === secondPrompt) {
+          return failResponse();
+        }
+        return okResponse();
+      },
+      recordEventQueued: async () => okResponse(),
+      upsertSessionSummary: () => {},
+      heartbeatPath: join(dir, "heartbeat.json"),
+      isShuttingDown: () => false,
+      processRetryQueue: () => {},
+      runConsolidation: async () => {},
+    });
+
+    try {
+      const failedLineOffset = Buffer.byteLength(`${firstLine}\n`, "utf8");
+      const firstIngest = coordinator.ingestCursorHistory();
+      expect(firstIngest.ok).toBe(true);
+      expect(firstIngest.items[0]).toMatchObject({
+        events_imported: 1,
+        hooks_events_imported: 1,
+        hooks_events_failed: 1,
+        retry_offset: failedLineOffset,
+      });
+      expect((firstIngest.items[0] as { last_record_error?: string }).last_record_error).toContain(
+        "write embedding is unavailable"
+      );
+      expect(recorded.map((event) => event.payload?.prompt)).toEqual([
+        "cursor hook retry first prompt",
+        secondPrompt,
+      ]);
+
+      const offsetAfterFailure = db
+        .query(`SELECT offset FROM mem_ingest_offsets WHERE source_key = ?`)
+        .get(`cursor_hooks:${cursorEventsPath}`) as { offset: number } | null;
+      expect(offsetAfterFailure?.offset).toBe(failedLineOffset);
+
+      recorded.length = 0;
+      failSecondPrompt = false;
+      const secondIngest = coordinator.ingestCursorHistory();
+      expect(secondIngest.ok).toBe(true);
+      expect(secondIngest.items[0]).toMatchObject({
+        events_imported: 1,
+        hooks_events_imported: 1,
+        hooks_events_failed: 0,
+      });
+      expect(recorded.map((event) => event.payload?.prompt)).toEqual([secondPrompt]);
+
+      const offsetAfterRetry = db
+        .query(`SELECT offset FROM mem_ingest_offsets WHERE source_key = ?`)
+        .get(`cursor_hooks:${cursorEventsPath}`) as { offset: number } | null;
+      expect(offsetAfterRetry?.offset).toBe(Buffer.byteLength(fileContent, "utf8"));
+    } finally {
+      db.close(false);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds cursor hook ingest work per run and resumes from deferred offset", () => {
+    const dir = mkdtempSync(join(tmpdir(), "harness-mem-cursor-hooks-bounded-"));
+    const cursorEventsPath = join(dir, "cursor", "events.jsonl");
+    mkdirSync(join(dir, "cursor"), { recursive: true });
+
+    const lines = Array.from({ length: 55 }, (_, index) =>
+      JSON.stringify({
+        hook_event_name: "beforeSubmitPrompt",
+        conversation_id: "cursor-bounded-1",
+        workspace_roots: [join(dir, "project")],
+        prompt: `cursor bounded prompt ${index}`,
+        timestamp: `2026-02-16T10:00:${String(index).padStart(2, "0")}.000Z`,
+      })
+    );
+    const fileContent = `${lines.join("\n")}\n`;
+    writeFileSync(cursorEventsPath, fileContent, "utf8");
+
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE mem_ingest_offsets(
+        source_key TEXT PRIMARY KEY,
+        offset INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+
+    const config: Config = {
+      dbPath: join(dir, "harness-mem.db"),
+      bindHost: "127.0.0.1",
+      bindPort: 0,
+      vectorDimension: 64,
+      captureEnabled: true,
+      retrievalEnabled: true,
+      injectionEnabled: true,
+      codexHistoryEnabled: false,
+      codexProjectRoot: dir,
+      codexSessionsRoot: join(dir, "codex-sessions"),
+      codexIngestIntervalMs: 3600000,
+      codexBackfillHours: 24,
+      cursorIngestEnabled: true,
+      cursorEventsPath,
+      cursorBackfillHours: 24,
+    };
+
+    const okResponse = (): ApiResponse => ({
+      ok: true,
+      source: "core",
+      items: [],
+      meta: {
+        count: 0,
+        latency_ms: 0,
+        sla_latency_ms: 200,
+        filters: {},
+        ranking: "test",
+      },
+    });
+
+    const recorded: EventEnvelope[] = [];
+    const coordinator = new IngestCoordinator({
+      db,
+      config,
+      recordEvent: (event) => {
+        recorded.push(event);
+        return okResponse();
+      },
+      recordEventQueued: async () => okResponse(),
+      upsertSessionSummary: () => {},
+      heartbeatPath: join(dir, "heartbeat.json"),
+      isShuttingDown: () => false,
+      processRetryQueue: () => {},
+      runConsolidation: async () => {},
+    });
+
+    try {
+      const deferredOffset = Buffer.byteLength(`${lines.slice(0, 50).join("\n")}\n`, "utf8");
+      const firstIngest = coordinator.ingestCursorHistory();
+      expect(firstIngest.ok).toBe(true);
+      expect(firstIngest.items[0]).toMatchObject({
+        events_imported: 50,
+        hooks_events_imported: 50,
+        hooks_events_failed: 0,
+        hooks_events_deferred: 5,
+        retry_offset: deferredOffset,
+      });
+      expect(recorded).toHaveLength(50);
+
+      const offsetAfterFirst = db
+        .query(`SELECT offset FROM mem_ingest_offsets WHERE source_key = ?`)
+        .get(`cursor_hooks:${cursorEventsPath}`) as { offset: number } | null;
+      expect(offsetAfterFirst?.offset).toBe(deferredOffset);
+
+      recorded.length = 0;
+      const secondIngest = coordinator.ingestCursorHistory();
+      expect(secondIngest.ok).toBe(true);
+      expect(secondIngest.items[0]).toMatchObject({
+        events_imported: 5,
+        hooks_events_imported: 5,
+        hooks_events_failed: 0,
+        hooks_events_deferred: 0,
+      });
+      expect(recorded).toHaveLength(5);
+
+      const offsetAfterSecond = db
+        .query(`SELECT offset FROM mem_ingest_offsets WHERE source_key = ?`)
+        .get(`cursor_hooks:${cursorEventsPath}`) as { offset: number } | null;
+      expect(offsetAfterSecond?.offset).toBe(Buffer.byteLength(fileContent, "utf8"));
+    } finally {
+      db.close(false);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("skips old backfill, ingests delta, separates projects, and search finds prompt + assistant", async () => {
     const runtime = createRuntime("hooks");
     const { baseUrl, cursorEventsPath } = runtime;


### PR DESCRIPTION
## Summary
- Keep failed Cursor hook spool events retryable by stopping the ingest offset at the failed line.
- Bound Cursor hook ingest to small batches and return retry/deferred metadata so large spool replays do not block daemon readiness.
- Record the investigation and validation in Plans.md.

## Test plan
- `bun test memory-server/tests/integration/ingest-cursor-hooks.test.ts`
- `cd memory-server && bun run typecheck`
- `git diff --check`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * カーソルフック取り込み時の処理上限を設定し、バッチ処理を改善
  * エラーハンドリング機構を強化し、失敗情報と再試行オフセットをAPI応答に追加

* **Tests**
  * カーソルフック取り込みの失敗リトライ挙動を検証するテストを追加
  * バッチ処理の上限と再開メカニズムを検証するテストを追加

* **Documentation**
  * Cursor Hooks 不具合の調査・修正方針に関するドキュメントを更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chachamaru127/harness-mem/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->