### PR TITLE
fix(test): unblock release workflow — read Plans.md + archive for S127-004

### DIFF
--- a/memory-server/tests/unit/hard-purge.test.ts
+++ b/memory-server/tests/unit/hard-purge.test.ts
@@ -1212,9 +1212,19 @@ describe("S127-004 hard purge risk gates", () => {
     }
   });
 
-  test("Plans.md marks S127-004 complete", () => {
-    const plans = readFileSync(join(import.meta.dir, "../../../Plans.md"), "utf8");
-    expect(plans).toContain("S127-004");
-    expect(plans).toMatch(/S127-004[\s\S]*?cc:完了/);
+  test("Plans.md (or archive) marks S127-004 complete", () => {
+    // S127-004 は 4bbe587 で `docs/archive/Plans-s108-s149-2026-06-11.md` に
+    // archive 済。Plans.md と archive 両方を読み、どちらかに完了マーカーがあれば
+    // pass。archive 後の Plans.md だけを読むと FAIL する (release-time の
+    // publish-npm gate を 1.5 ヶ月止めていた根本原因)。
+    const root = join(import.meta.dir, "../../..");
+    const plans = readFileSync(join(root, "Plans.md"), "utf8");
+    const archive = readFileSync(
+      join(root, "docs/archive/Plans-s108-s149-2026-06-11.md"),
+      "utf8",
+    );
+    const combined = `${plans}\n${archive}`;
+    expect(combined).toContain("S127-004");
+    expect(combined).toMatch(/S127-004[\s\S]*?cc:完了/);
   });
 });


### PR DESCRIPTION
## Summary

- `hard-purge.test.ts:1217` が Plans.md だけを読んでいたため、`4bbe587` で archive された S127-004 が見つからず publish-npm gate が fail
- 結果として **release.yml の github-release step が v0.27.5 と v0.28.0 で dependency-skip され、GitHub Release page が 1.5 ヶ月生成されていなかった** 根本原因を修正
- test を Plans.md + `docs/archive/Plans-s108-s149-2026-06-11.md` の結合に対する assert に変更

## Test plan

- [x] `bun test memory-server/tests/unit/hard-purge.test.ts -t "S127-004"` → 19/19 PASS
- [x] Plans.md と archive 両方を確認: archive に `S127-004 | ... | cc:完了 [8bb514b]` が存在
- [ ] Merge 後に release.yml workflow を v0.28.0 / v0.27.5 で manual re-run → GitHub Release page 生成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3yzU35mfzxnmUsKeAeKW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テスト内容を更新し、複数のソースファイルから情報を読み込んで検証するようにしました。テスト名およびコメントも、検証対象の範囲を明示する形に改められています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->