### PR TITLE
chore: release v0.28.1 — release workflow unblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-06-21
+
+### Fixed
+
+- **release workflow unblock — Plans.md archive 対応**: `memory-server/tests/unit/hard-purge.test.ts:1217` の `expect(plans).toContain("S127-004")` が `4bbe587` での Plans.md archive 後 fail し続けていた。test を Plans.md + `docs/archive/Plans-s108-s149-2026-06-11.md` の結合に対する assert に変更。**v0.27.5 と v0.28.0 で github-release step が publish-npm gate fail により dependency-skip され GitHub Release page が 1.5 ヶ月生成されていなかった根本原因の修正**。本 release v0.28.1 から release workflow が自動で github-release step に進む。
+
 ## [0.28.0] - 2026-06-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary

- PR #131 (test fix for Plans.md archive S127-004) を出荷する patch release
- §0.27.5 と §0.28.0 で github-release step が publish-npm gate fail により dependency-skip され、GitHub Release page が 1.5 ヶ月生成されていなかった事象を解消
- 本 release から release workflow が自動で github-release step に進む

## Test plan

- [x] PR #131 で test fix を merge 済 (61ecbea)
- [x] `bun test memory-server/tests/unit/hard-purge.test.ts` 19/19 PASS
- [x] CHANGELOG promote (0.28.1)
- [x] package.json bump (0.28.0 → 0.28.1)
- [ ] Merge 後 tag v0.28.1 push → release.yml workflow 完走 → GitHub Release page 自動生成確認

## v0.28.0 / v0.27.5 Release page について

本 release では復元しない。次回以降の release が正常化することを優先 (v0.28.0 / v0.27.5 の binaries はコミット履歴と tag からアクセス可能)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3yzU35mfzxnmUsKeAeKW