### PR TITLE
chore: release v0.28.3 — workflow decouple after fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.28.3] - 2026-06-23
+
+### Fixed
+
+- **release workflow 構造修正 — github-release を test 群から責務分離**: v0.27.5/v0.28.0/v0.28.1/v0.28.2 で連続して publish-npm gate fail により github-release step が dependency-skip され続けていた根本問題を解消。`github-release.needs` を `[publish-npm, go-build, go-native-smoke]` から `[go-build]` のみに変更 (PR #135)。CI design 原則 = test gate と release gate の責務分離。test fail で release page 生成を永久に止めるのは設計欠陥のため。本 release から binary 配布の Release page が test 修正サイクルと独立に常時生成される。test 層 (publish-npm) は引き続き fail 表示が残るが、これは別 PR で順次対応する負債 (現状 3 件確認: hard-purge.test.ts S127-004 ✅修正済 / api-contract.test.ts snapshot ✅修正済 / resume-pack-partial.test.ts §91-003 (b) ⏳ 未対応)。
+
 ## [0.28.2] - 2026-06-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Summary

- PR #135 (github-release を test 群から責務分離) を出荷する patch release
- **本 release から binary 配布の Release page が test 修正サイクルと独立に常時生成される最初の release**
- v0.27.5/v0.28.0/v0.28.1/v0.28.2 の 1.5 ヶ月間続いた github-release skip 問題を構造的に解消

## Test plan

- [x] PR #135 で workflow 修正を merge 済 (c885209)
- [x] CHANGELOG promote (0.28.3)
- [x] package.json bump (0.28.2 → 0.28.3)
- [ ] Merge 後 tag v0.28.3 push → release.yml workflow trigger → github-release step が initial run success → GitHub Release page 自動生成確認

## 残る test fail (別 PR で順次対応)

- resume-pack-partial.test.ts §91-003 (b) toBeFalsy fail
- Go MCP native smoke (windows) executable path issue
- (5 件目以降は未知数)

これらは publish-npm gate 内の表示 fail として残るが、本 release から Release page 生成は block されない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3yzU35mfzxnmUsKeAeKW