### PR TITLE
chore: release v0.28.6 — repair npm publish gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.27.5",
+    "version": "0.28.6",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.27.5",
+      "version": "0.28.6",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.27.5",
+  "version": "0.28.6",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.28.6] - 2026-07-06
+
+### Fixed
+
+- **npm publish gate repair (v0.27.5〜v0.28.5 corrective release)**: the tag-triggered Release workflow's `publish-npm` job had been failing since v0.27.5 (last npm publish: v0.27.4), so npm users never received 0.28.x. Root causes fixed: (1) benchmark SSOT proof lines were archived out of `Plans.md` by the 2026-06-11 maintenance commit, breaking `tests/benchmark-claim-ssot.test.ts` — restored; (2) two pre-existing type errors in `memory-server/src/server.ts` graph-neighbors enrichment failed the typecheck gate — fixed by removing an invalid `ApiResponse` cast; (3) `.claude-plugin/plugin.json` / `marketplace.json` versions were stuck at 0.27.5, failing the version-consistency gate — synced to the package version; (4) `tests/release-workflow-contract.test.ts` still expected the pre-2026-06-23 `github-release` job dependencies — updated to the documented design (binary distribution independent of test gates). No runtime behavior change beyond the type fix.
+
 ## [0.28.5] - 2026-07-06
 
 ### Changed
@@ -3046,7 +3052,8 @@ Setup and feed browsing became easier through an interactive setup flow and inli
 - Run `harness-mem setup` and confirm interactive prompts appear in sequence.
 - Open feed UI and confirm card details expand inline.
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.5...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.6...HEAD
+[0.28.6]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.5...v0.28.6
 [0.28.5]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.4...v0.28.5
 [0.27.5]: https://github.com/Chachamaru127/harness-mem/compare/v0.27.4...v0.27.5
 [0.27.4]: https://github.com/Chachamaru127/harness-mem/compare/v0.27.3...v0.27.4

--- a/Plans.md
+++ b/Plans.md
@@ -19,6 +19,12 @@
 
 **§75 + §76 Go MCP Migration — 完了**（2026-04-10）/ §74 Search Precision & Recall Granularity — 完了 / §73 Codex bootstrap reproducibility — 完了
 
+- benchmark SSOT: `generated_at=2026-05-27T07:20:23.753Z`, `git_sha=eb88c96`
+- Japanese companion current: `overall_f1_mean=0.6580`
+- Japanese historical baseline: `overall_f1_mean=0.8020`
+
+（この 3 行は `tests/benchmark-claim-ssot.test.ts` の release publish gate が Plans.md に要求する正本参照。2026-06-11 の maintenance archive (4bbe587) で誤って archive 側へ移動し、v0.27.5〜v0.28.5 の npm publish が gate failure で停止していた。値の正本は `memory-server/src/benchmark/results/ci-run-manifest-latest.json` と `docs/benchmarks/artifacts/{s43-ja-release-v2,s40-ja-baseline}-latest/summary.json`）
+
 ## §128 Recall Runtime Architecture — cc:完了 [enforce gate f35c21d / closeout a6808bd; post-完了 regression は §130/S130-009a が吸収]
 
 策定日: 2026-05-22

--- a/memory-server/src/server.ts
+++ b/memory-server/src/server.ts
@@ -2051,7 +2051,7 @@ export function startHarnessMemServer(core: HarnessMemCore, config: Config) {
 
             const validKinds: Set<RelationKind> = new Set(["is_a", "uses", "fixes", "generic"]);
             const enriched = {
-              ...(linkResult as Record<string, unknown>),
+              ...linkResult,
               entities: entityRows.map((r) => ({
                 id: r.name.toLowerCase(),
                 label: r.name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {

--- a/tests/release-workflow-contract.test.ts
+++ b/tests/release-workflow-contract.test.ts
@@ -80,7 +80,10 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("npm run benchmark:developer-domain");
     expect(workflow).toContain("go-native-smoke:");
     expect(workflow).toContain("name: Go MCP native smoke (${{ matrix.label }})");
-    expect(workflow).toContain("needs: [publish-npm, go-build, go-native-smoke]");
+    // 2026-06-23 設計変更: github-release は binary 配布の責務のみ (go-build のみ依存)。
+    // test gate (publish-npm) の失敗で release page 生成を塞がない。
+    expect(workflow).toContain("needs: [go-build]");
+    expect(workflow).not.toContain("needs: [publish-npm, go-build, go-native-smoke]");
     expect(workflow).not.toContain("name: Run memory server quality gates");
     expect(workflow).not.toContain("cd memory-server\n          bun run test");
   });


### PR DESCRIPTION
Corrective release: npm publish has been failing since v0.27.5 (last published: v0.27.4). Fixes all 4 gate breakages so `publish-npm` can pass again:

1. **benchmark-claim-ssot gate**: benchmark SSOT proof lines were archived out of Plans.md by 4bbe587 (2026-06-11 maintenance) — restored with a pointer note
2. **typecheck gate**: 2 pre-existing type errors in `memory-server/src/server.ts` graph-neighbors enrichment — fixed by removing an invalid `ApiResponse` cast
3. **version-consistency gate**: `.claude-plugin/plugin.json` / `marketplace.json` stuck at 0.27.5 — synced to package version
4. **release-workflow-contract**: test still expected pre-2026-06-23 `github-release` job deps — updated to the documented independence design

Verification: full `npm test` (repository behavior gate) exit 0 / zero fails, `memory-server bun run typecheck` exit 0.

Note: tag v0.28.6 will be pushed after the npm auth (NPM_TOKEN) is renewed — publish would fail on auth otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMDZUFooFFcX2k2r1mfmiJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * リリース配信の不整合を修正し、0.28.x が正しく公開されるようになりました。
  * グラフ近傍の応答処理での型エラーを解消しました。

* **Chores**
  * プラグインとアプリのバージョンを `0.28.6` に更新しました。
  * リリース履歴と関連参照情報を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->