### PR TITLE
chore(release): v0.29.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.28.9",
+    "version": "0.29.0",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.28.9",
+      "version": "0.29.0",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.28.9",
+  "version": "0.29.0",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-16
+
+### Added
+
+- **Hermes MemoryProvider Layer 2 integration**: added a discoverable Hermes provider with bounded background sync, prefetch, shutdown handling, installation guidance, rollback instructions, and end-to-end coverage.
+- **Hermes-aware memory ranking and provenance**: direct Hermes hits are stably prioritized without hard-filtering useful cross-tool memories, including continuous Japanese text matching, while the allowlisted `metadata.source` identifies safe provenance in normal and degraded search paths.
+
+### Changed
+
+- **Fact extraction is local-first and safe by default**: heuristic extraction remains the default. When LLM extraction is explicitly enabled, the default provider is local Ollama on loopback; blocked or unavailable LLM paths fall back deterministically to heuristic extraction or an empty diff.
+- **Event metadata persistence is allowlist-only**: only `source` is persisted through event, observation, and search projections. Arbitrary metadata is neither stored nor returned.
+
+### Security
+
+- **Fact-extraction egress is fail-closed**: Ollama accepts only `localhost`, `127.0.0.1`, or `::1`; non-loopback Ollama is rejected even when external LLM use is allowed. OpenAI, Anthropic, and Gemini require both an explicit external-LLM allow flag and provider credentials.
+- **Audit output excludes sensitive content**: egress audit records contain metadata such as provider and payload size, but not conversation bodies, API keys, tokens, or secrets.
+
+### Fixed
+
+- **Provider shutdown regression coverage**: the existing bounded `join(timeout=10.0)` behavior is now pinned by tests so pending sync work cannot block shutdown indefinitely.
+- **Hermes event provenance no longer disappears after ingest**: fixed the event-to-observation mapping gap and added fresh/migrated SQLite plus PostgreSQL schema parity for allowlisted source metadata.
+
+### Verification
+
+- Hermes Provider: 17 tests passed.
+- LLM and metadata security suites: 130 tests passed with 0 failures.
+- Isolated loopback Ollama smoke: conversation record → consolidation → one fact → search passed with zero external-egress audit entries. No live cloud LLM was used.
+
 ## [0.28.9] - 2026-07-07
 
 ### Fixed
@@ -3076,7 +3104,8 @@ Setup and feed browsing became easier through an interactive setup flow and inli
 - Run `harness-mem setup` and confirm interactive prompts appear in sequence.
 - Open feed UI and confirm card details expand inline.
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0
 [0.28.9]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.8...v0.28.9
 [0.28.8]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.7...v0.28.8
 [0.28.7]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.6...v0.28.7

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,9 +7,19 @@
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-16
+
 ### ユーザー向け要約
 
-- **§156 fresh install の Granite default と既存ユーザー向け移行 notice を追加**。新規 `harness-mem setup` は online 時に pin 済み `granite-embedding-311m-r2` を準備し、`--skip-model-pull`、offline / CI / sandbox skip warning、LaunchAgent embedding env 同期に対応した。既存 installation は自動切替せず、`/health`、起動ログ、`doctor --json` の `embedding_model` warning で pull / backfill / flag flip / rollback 手順を案内する。
+- **Hermes MemoryProvider Layer 2連携を追加**。Hermesの会話をharness-memへ安全に記録し、関連する記憶を事前取得できる。終了時の待機は上限付きで、導入・確認・ロールバック手順も文書化した。
+- **事実抽出をlocal-first化**。既定は従来どおりheuristic。LLM抽出を明示した場合はloopbackのOllamaを既定とし、OpenAI・Anthropic・Geminiは外部利用の明示許可とcredentialの両方がある場合だけ使用する。
+- **検索結果の出どころを安全に保持**。`metadata.source`だけをallowlistし、任意metadata、API key、token、secretは保存も返却もしない。
+- **Hermes関連の検索順位を改善**。直接関係するHermesの記憶を安定して優先しつつ、関連する他ツールの記憶はhard filterで捨てない。日本語の連続文字列にも対応する。
+
+### 検証
+
+- Hermes Provider 17件、LLM・metadata security 130件がPASS。
+- 隔離したloopback Ollamaで、会話記録→consolidation→fact生成→検索を実機確認。外部送信auditは0件で、live cloud LLMは使用していない。
 
 ## [0.27.4] - 2026-06-05
 
@@ -1051,7 +1061,8 @@ v0.11.0 での対応:
 
 - 詳細な変更点、移行ノート、検証手順は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.8...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0
 [0.25.8]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.7...v0.25.8
 [0.25.7]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.6...v0.25.7
 [0.25.6]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.5...v0.25.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.28.9",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.28.9",
+      "version": "0.29.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@huggingface/transformers": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.28.9",
+  "version": "0.29.0",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Release v0.29.0

Hermes MemoryProvider Layer 2とlocal-first fact extractionを正式リリースします。

### Added
- Hermes MemoryProvider lifecycle: discovery, bounded sync, prefetch, shutdown, setup, rollback
- Hermes-aware stable ranking with continuous Japanese text support
- allowlisted `metadata.source` provenance for normal/degraded search

### Security
- heuristic remains the default extractor mode
- explicit LLM mode defaults to loopback Ollama
- remote Ollama is rejected
- OpenAI / Anthropic / Gemini require explicit external allow + credential
- audit output excludes conversation bodies and secrets

### Verification
- Hermes Provider: 17 passed
- LLM and metadata security suites: 130 passed / 0 failed
- Release contract + marketplace: 23 passed
- Plugin manifest validation: PASS
- npm pack dry-run: PASS (`@chachamaru127/harness-mem@0.29.0`, 620 entries)
- isolated loopback Ollama smoke: record → consolidation → fact → search PASS, external egress audit 0

### Scope
Release-only commit `52c5dc5`; 6 files:
- `.claude-plugin/marketplace.json`
- `.claude-plugin/plugin.json`
- `CHANGELOG.md`
- `CHANGELOG_ja.md`
- `package-lock.json`
- `package.json`

### Explicit exclusions
- local §158 commit `decd5a0`
- preserved stashes and registered worker worktrees
- LaunchAgent / production daemon configuration
- live cloud LLM execution

Release tags are created only after this PR reaches `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Hermes MemoryProvider Layer 2連携、メモリ検索順位の改善、出自情報の保持に対応。
  * Fact抽出をローカル優先に変更し、外部LLM利用時の安全なフォールバックを追加。
* **セキュリティ**
  * 保存メタデータを必要最小限に制限し、外部送信を安全に制御。
  * 監査出力から会話本文や認証情報を除外。
* **バグ修正**
  * Provider終了処理や出自情報の保持に関する問題を修正。
* **ドキュメント**
  * v0.29.0の変更履歴と検証結果を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->