### PR TITLE
chore(release): v0.29.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g npm@latest
+          npm install -g npm@11.5.1
           npm --version
 
       - name: Setup Bun

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-07-17
+
+### Fixed
+
+- **Restored npm OIDC publishing on the Node 20 release runner**: pinned the release workflow to npm `11.5.1` instead of `npm@latest`, preventing npm 12's Node 22+ engine requirement from stopping package publication.
+
 ## [0.29.0] - 2026-07-16
 
 ### Added
@@ -3104,7 +3110,8 @@ Setup and feed browsing became easier through an interactive setup flow and inli
 - Run `harness-mem setup` and confirm interactive prompts appear in sequence.
 - Open feed UI and confirm card details expand inline.
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...HEAD
+[0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0
 [0.28.9]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.8...v0.28.9
 [0.28.8]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.7...v0.28.8

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-07-17
+
+### 修正
+
+- **Node 20のrelease runnerでnpm OIDC公開経路を復旧**。`npm@latest`がNode 22以上を要求するnpm 12へ進んで公開が停止する問題を、Node 20互換のnpm `11.5.1`固定で解消した。
+
 ## [0.29.0] - 2026-07-16
 
 ### ユーザー向け要約
@@ -1061,7 +1067,8 @@ v0.11.0 での対応:
 
 - 詳細な変更点、移行ノート、検証手順は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...HEAD
+[0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0
 [0.25.8]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.7...v0.25.8
 [0.25.7]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.6...v0.25.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "BUSL-1.1",
       "dependencies": {
         "@huggingface/transformers": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {

--- a/tests/release-workflow-contract.test.ts
+++ b/tests/release-workflow-contract.test.ts
@@ -58,6 +58,12 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("chmod +x bin/harness-mcp-*");
     expect(workflow).toContain("name: Install release runner prerequisites");
     expect(workflow).toContain("sudo apt-get install -y jq ripgrep");
+    // npm 12 requires Node 22+, while the publish job intentionally uses Node 20.
+    // Keep OIDC trusted publishing on the minimum compatible npm release.
+    expect(workflow).toContain("node-version: 20");
+    expect(workflow).toContain("npm install -g npm@11.5.1");
+    expect(workflow).not.toContain("npm install -g npm@latest");
+    expect(workflow).toContain("id-token: write");
     expect(workflow).toContain("name: Install MCP server dependencies");
     expect(workflow).toContain("cd mcp-server");
     expect(workflow).toContain("npm ci");


### PR DESCRIPTION
## Release v0.29.1

v0.29.0で停止したnpm OIDC公開経路を復旧するpatch releaseです。製品機能はv0.29.0と同一です。

### Root cause

Release workflowはNode 20上で`npm install -g npm@latest`を実行していました。npm latestが12.0.1へ進み、Node 22.22.2以上を要求したため、`EBADENGINE`で`npm publish`より前に停止しました。

### Fix

- Node 20互換かつOIDC trusted publishing要件を満たすnpm `11.5.1`へ固定
- `npm@latest`を禁止し、Node 20 + npm 11.5.1契約を固定する回帰テストを追加
- package/plugin/marketplace versionを`0.29.1`へ同期
- CHANGELOG英日を更新

### TDD / verification

- RED: 現行`npm@latest`に対してrelease workflow contractが期待どおりFAIL
- GREEN: `npm@11.5.1`固定後にPASS
- Release workflow contract + marketplace: 23 passed
- Plugin manifest validation: PASS
- npm pack dry-run: PASS (`@chachamaru127/harness-mem@0.29.1`, 620 entries)
- `git diff --check`: PASS

### Distribution note

- v0.29.0 GitHub Releaseと4バイナリは公開済みのまま保持します。
- v0.29.0のnpm packageは未公開です。
- v0.29.1をv0.29系の正規npm公開版にします。

### Explicit exclusions

- local §158 commit `decd5a0`
- preserved stashes and registered worker worktrees
- LaunchAgent / production daemon configuration
- v0.29.0 tag / GitHub Releaseの変更
