### PR TITLE
chore(release): v0.29.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.2] - 2026-07-21
+
+### Documentation
+
+- **Made Hermes MemoryProvider visible from the repository and npm entrypoint**: refreshed the English and Japanese root READMEs with a clearer cross-agent value proposition, Layer 1 MCP vs Layer 2 MemoryProvider guidance, installation paths, architecture, support tiers, and links to the detailed Hermes quickstart and operations guide.
+- **Documented local-first fact extraction at the point of adoption**: added the `heuristic` default, explicit loopback Ollama configuration, external-cloud allow + credential gate, non-loopback Ollama rejection, and the isolated live-smoke result so operators can understand the privacy boundary before enabling LLM extraction.
+
 ## [0.29.1] - 2026-07-17
 
 ### Fixed
@@ -3110,7 +3117,8 @@ Setup and feed browsing became easier through an interactive setup flow and inli
 - Run `harness-mem setup` and confirm interactive prompts appear in sequence.
 - Open feed UI and confirm card details expand inline.
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...HEAD
+[0.29.2]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0
 [0.28.9]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.8...v0.28.9

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,6 +7,13 @@
 
 ## [Unreleased]
 
+## [0.29.2] - 2026-07-21
+
+### ドキュメント
+
+- **GitHubとnpmの入口からHermes MemoryProviderを理解できるREADMEへ更新**。英語・日本語のルートREADMEに、cross-agentの価値、Layer 1 MCP / Layer 2 MemoryProvider、導入経路、architecture、support tier、詳細ガイドへの導線を追加した。
+- **local-first事実抽出の安全境界を導入前に確認できるようにした**。`heuristic`既定、loopback Ollamaの明示設定、外部クラウドのallow + credential gate、非loopback Ollama拒否、隔離live smokeの実測結果をREADMEへ追加した。
+
 ## [0.29.1] - 2026-07-17
 
 ### 修正
@@ -1067,7 +1074,8 @@ v0.11.0 での対応:
 
 - 詳細な変更点、移行ノート、検証手順は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...HEAD
+[0.29.2]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0
 [0.25.8]: https://github.com/Chachamaru127/harness-mem/compare/v0.25.7...v0.25.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "BUSL-1.1",
       "dependencies": {
         "@huggingface/transformers": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## Release v0.29.2

README documentation patch that makes the v0.29 Hermes MemoryProvider and local-first fact extraction visible from the GitHub and npm entrypoints.

### Changes

- Promote the README update merged in PR #149 into the npm package entrypoint
- Add English and Japanese CHANGELOG entries for the Hermes Layer 1/Layer 2 guidance
- Document the `heuristic` default, loopback Ollama path, cloud allow + credential gate, and non-loopback rejection at the adoption point
- Bump all release surfaces from `0.29.1` to `0.29.2`

### Release surfaces

- `package.json`
- `package-lock.json`
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `CHANGELOG.md`
- `CHANGELOG_ja.md`

### Verification

- [x] Version surfaces all equal `0.29.2`
- [x] `git diff --check`
- [x] Release workflow + marketplace tests: 23 passed
- [x] Claude plugin manifest validation passed
- [x] `npm pack --dry-run`: `@chachamaru127/harness-mem@0.29.2`, 620 entries, updated `README.md` included
- [x] Plugin tag dry-run: `harness-mem--v0.29.2`
- [x] §158 commit `decd5a0` excluded

### Scope

Documentation and release metadata only. No product code, daemon configuration, LaunchAgent, database, or external LLM behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リリース**
  * バージョンを **0.29.2** に更新しました。

* **ドキュメント**
  * Hermes MemoryProvider の概要、導入方法、アーキテクチャ、サポート範囲をREADMEに追加しました。
  * ローカル優先の事実抽出に関する設定、安全境界、プライバシー上の注意点を明記しました。
  * 英語・日本語の変更履歴を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->