### PR TITLE
chore(release): v0.29.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.29.2",
+    "version": "0.29.3",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.3] - 2026-07-26
+
+### Fixed
+
+- **The 0.29.2 documentation work now reaches npm**: v0.29.2 was tagged and GitHub-released but never published, because `publish-npm` stopped at the repository behavior gate — `tests/readme-claim-ceiling.test.ts` compared the shipped README against a claim map that still described the pre-Hermes scope. The claim map SSOT (`docs/readme-claims.md`, `docs/readme-claims-ja.md`) now carries the Hermes-inclusive lead tagline plus explicit rows for Layer 1 MCP / Layer 2 MemoryProvider participation and the fact-extraction egress contract, so the gate passes and the same content ships as 0.29.3. `github-release` depends only on `go-build`, which is why the tag and release page appeared while the package did not.
+- **CodingMemory bench smoke installs its Python test dependency**: `codingmemory-bench-smoke.yml` sets up Python 3.11 and installs `pytest>=8,<9` for the PII test path, pinned by `tests/benchmark-claim-ssot.test.ts` so the dependency cannot silently disappear again.
+
+### Verification
+
+- Repository behavior gate (`npm test`) on the release content: 2369 passed. The only failure was `memory-server/tests/performance/repository-regression.test.ts` `findMany`, a load-sensitive micro-benchmark that measured ratio 1.317 against a 1.30 ceiling and passed on re-run (1.230, 1.018); it is unrelated to this change set.
+- README claim ceiling gate: 8 passed.
+
 ## [0.29.2] - 2026-07-21
 
 ### Documentation
@@ -3117,7 +3129,8 @@ Setup and feed browsing became easier through an interactive setup flow and inli
 - Run `harness-mem setup` and confirm interactive prompts appear in sequence.
 - Open feed UI and confirm card details expand inline.
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.3...HEAD
+[0.29.3]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...v0.29.3
 [0.29.2]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,6 +7,18 @@
 
 ## [Unreleased]
 
+## [0.29.3] - 2026-07-26
+
+### 修正
+
+- **0.29.2 のドキュメント成果を npm に到達させた**。v0.29.2 は tag と GitHub Release まで進んだが npm 未公開だった。`publish-npm` が repository behavior gate で停止し、`tests/readme-claim-ceiling.test.ts` が実 README と Hermes 追加前の claim map を比較して fail していたため。claim map SSOT (`docs/readme-claims.md`、`docs/readme-claims-ja.md`) を Hermes を含む lead tagline に更新し、Layer 1 MCP / Layer 2 MemoryProvider の参加条件と事実抽出の egress contract の行を追加した。`github-release` は `go-build` にのみ依存するため、tag と release page だけが先に出る構造だった。
+- **CodingMemory bench smoke に Python テスト依存を追加**。`codingmemory-bench-smoke.yml` が Python 3.11 と `pytest>=8,<9` を導入する。`tests/benchmark-claim-ssot.test.ts` で pin し、同じ依存欠落が再発しないようにした。
+
+### 検証
+
+- リリース内容に対する repository behavior gate (`npm test`): 2369 passed。唯一の fail は `memory-server/tests/performance/repository-regression.test.ts` の `findMany` で、負荷依存のマイクロベンチ (ratio 1.317 / 上限 1.30)。再実行では 1.230、1.018 で pass し、本変更とは無関係。
+- README claim ceiling gate: 8 passed。
+
 ## [0.29.2] - 2026-07-21
 
 ### ドキュメント
@@ -1074,7 +1086,8 @@ v0.11.0 での対応:
 
 - 詳細な変更点、移行ノート、検証手順は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.3...HEAD
+[0.29.3]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...v0.29.3
 [0.29.2]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/Chachamaru127/harness-mem/compare/v0.28.9...v0.29.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "BUSL-1.1",
       "dependencies": {
         "@huggingface/transformers": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## 目的

v0.29.2 は tag と GitHub Release まで到達したが **npm 未公開**のまま止まっていた。同内容を 0.29.3 として公開し直す。

## v0.29.2 が公開されなかった理由

`publish-npm` job の "Run repository behavior gate" で `tests/readme-claim-ceiling.test.ts` が 2 件 fail していた([該当 run](https://github.com/Chachamaru127/harness-mem/actions/runs/29797013546))。実 README が Hermes を含む記述に更新された一方、claim map SSOT が Hermes 追加前のスコープを保持していたため。

`github-release` job は `go-build` にのみ依存する設計なので、パッケージ公開が失敗しても tag と release page だけが生成された。

修正は PR #151 (`8dbcda0` claim map 同期 + `bd43d9c` CodingMemory smoke の pytest 追加) で main に merge 済み。

## この PR の内容

version 6 面の bump と CHANGELOG 昇格のみ。コード変更なし。

| 面 | 変更 |
|---|---|
| `package.json` | 0.29.2 → 0.29.3 |
| `package-lock.json` | root + `packages[""]` の 2 箇所 |
| `.claude-plugin/plugin.json` | 0.29.2 → 0.29.3 |
| `.claude-plugin/marketplace.json` | `metadata.version` + `plugins[0].version` |
| `CHANGELOG.md` | `[0.29.3] - 2026-07-26` 追加 + compare link |
| `CHANGELOG_ja.md` | 同内容の要約 + compare link |

## ローカル検証

tag を切る前に、v0.29.2 を落としたゲートをローカル再現した。

- `npm test` (repository behavior gate): **2369 passed / 1 failed**
  - 唯一の fail は `memory-server/tests/performance/repository-regression.test.ts` の `findMany`。負荷依存のマイクロベンチで ratio 1.317 に対し上限 1.30。再実行 2 回は 1.230 / 1.018 で pass するため flaky と判定し、本変更とは無関係。
- `tests/readme-claim-ceiling.test.ts` (v0.29.2 の failure 箇所): **8 passed**
- `tests/marketplace-schema.test.ts` + `release-docs-contract` + `benchmark-claim-ssot`: **44 passed**
- `tests/release-workflow-contract.test.ts`: **1 passed**
- `npm pack --dry-run`: `chachamaru127-harness-mem-0.29.3.tgz` (5.4 MB / 620 files)

補足: ローカルでゲートを再現するには worktree で依存を導入しておく必要がある (`bun install --frozen-lockfile`)。未導入だと sharp が bun の global cache から libvips を解決できず、`embedding-e5-parity` が環境要因で fail する。

## merge 後の手順

main に merge 後、main 上の commit に `v0.29.3` tag を打って push する。`release.yml` は tag commit が `origin/main` に含まれることを検証するため、この順序が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpnahrTWrJ2DPZhesch6dZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リリース**
  * バージョンを **0.29.3** に更新しました。
* **ドキュメント**
  * 日本語・英語の変更履歴に v0.29.3 の内容と比較リンクを追加しました。
  * README の公開情報に関する修正を反映しました。
* **検証**
  * テスト、README の検証、ベンチマークのスモークチェック結果を変更履歴に記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->