### PR TITLE
chore(gitignore): root 直下の .harness-worktrees/ を無視対象に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ mcp-server-go/bin/
 integrations/hermes/plugin/*.egg-info/
 
 # Worker worktrees created by harness/claude-worker topology
+.harness-worktrees/
 memory-server/.harness-worktrees/
 
 # Live progress snapshot artifact


### PR DESCRIPTION
## 症状

`git status` に `.harness-worktrees/` が untracked として常に残る。

## 原因

harness/claude-worker topology は worker worktree を repo root 直下の `.harness-worktrees/` にも作るが、`.gitignore` は `memory-server/.harness-worktrees/` だけを登録していた。

## 変更

既存の同種エントリの隣に root 側のパターンを 1 行追加する。

```
# Worker worktrees created by harness/claude-worker topology
.harness-worktrees/
memory-server/.harness-worktrees/
```

## 実体の扱い(この PR の対象外)

root 直下には**登録済みの worker worktree が 2 件、計 443MB** 残っている。無視設定とは独立の判断なので触っていない。

| worktree | branch | main 取り込み |
|---|---|---|
| `40bd346a-…` (2026-06-13) | `harness/worker/40bd346a-…` | 取り込み済み |
| `5bdba085-…` (2026-06-20) | `harness/worker/5bdba085-…` | **未取り込み** |

後者は s154-711 / s154-FU02 の 4 commit を持つ。Plans.md 154-711 は `cc:完了 [6140691]` で、記録上は Lead が手動 cherry-pick して main に取り込んでいるため内容は重複の可能性が高い。ただし SHA が異なるため同一性は未確認。

削除するなら取り込み確認のうえで operator 判断とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpnahrTWrJ2DPZhesch6dZ