### PR TITLE
fix(consolidation): 起動時に running のまま残った job を回収する (§160-004)

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -1408,6 +1408,8 @@ consolidation の寄与は 28 → 23 の差分 (~5) で副次的。両者は同�
 | 160-002 | 160-001 で特定した区間の改善。候補は index 追加、FTS 挿入の遅延化、vector 書き込みの batch 化、cold cache 対策 (`PRAGMA mmap_size` 等)。**特定前に着手しない** | 本番 tick の最大ブロックが budget + 1 単位に収まる。検索品質は非回帰 (e5 parity / dev-domain / CJK) | 160-001 | cc:TODO |
 | 160-003 | `tests/session-start-parity-contract.test.ts` が**ローカル daemon の応答性に依存**している。2026-07-28 に daemon が catch-up でブロック中だと spawn した hook が 5s timeout し false fail した (daemon 平常時は 3 回連続 5 passed)。§159-008 で閉じた `CLAUDE_PLUGIN_DATA` 漏れとは別の依存 | 本番 daemon がブロック中でも同じ結果になる。hook が実 daemon に触れる経路を stub 化するか、port を隔離する | - | cc:TODO |
 
+| 160-004 | consolidation job が `running` のまま残り、誰も片付けないため単調に増える。daemon プロセス内で走るので SIGKILL / crash / launchd 再起動で中断されると回収されない。2026-07-28 の本番で **49 件の孤児** (最古 2026-05-17、最新 2026-07-26、うち 42 件は 2026-06-25 の 1 事故) が残っており、`/v1/admin/consolidation/status` の `running_jobs` が実態と乖離していた。**これを見た調査エージェントが「worker pool がスタック」と誤診し、本番 daemon の再起動を推奨した**(実際は 7 分で 3 件完了・pending 0 の健全な状態)。起動時に `failed` へ倒して理由を残す | (a) 起動時に `running` が 0 になり `error` に理由が残る、(b) `completed` / `pending` は変えない、(c) `running` が無ければ何も変えない (冪等)、(d) 2 test pass | - | cc:完了 [本 PR] |
+
 ### Non-goals / stop line
 
 - §159 の tick budget 機構を作り直さない。ループ構造は実測で妥当と確認済み (非 200 3 / 300、p95 14ms)。

--- a/memory-server/src/core/harness-mem-core.ts
+++ b/memory-server/src/core/harness-mem-core.ts
@@ -2613,6 +2613,45 @@ export class HarnessMemCore {
     migrateDbSchema(this.db);
     this.ftsEnabled = initFtsFromDb(this.db);
     this.migrateLegacyProjectAliases();
+    this.reconcileAbandonedConsolidationJobs();
+  }
+
+  /**
+   * §160-004: 起動時に `running` のまま残った consolidation job を回収する。
+   *
+   * consolidation は daemon プロセス内で走るので、SIGKILL / crash / launchd の
+   * 再起動で中断されると `mem_consolidation_queue` の行が `running` のまま残る。
+   * 誰も片付けないため単調に増え、`/v1/admin/consolidation/status` の
+   * `running_jobs` が実態と乖離する。
+   *
+   * 2026-07-28 の本番実測で 49 件の孤児 (最古 2026-05-17、最新 2026-07-26、
+   * うち 42 件は 2026-06-25 の 1 事故) が残っており、これを見た調査エージェントが
+   * 「worker pool がスタックしている」と誤診して本番 daemon の再起動を推奨した。
+   * 実際は 7 分で 3 件完了・pending 0 の健全な状態だった。
+   *
+   * 起動した時点で前プロセスの job は生きていないので、`failed` へ倒して
+   * 理由を残す。単一プロセス設計 (lock file で多重起動を防いでいる) が前提。
+   */
+  private reconcileAbandonedConsolidationJobs(): void {
+    try {
+      const result = this.db
+        .query(
+          `UPDATE mem_consolidation_queue
+             SET status = 'failed',
+                 finished_at = ?,
+                 error = 'abandoned: daemon restarted while job was running'
+           WHERE status = 'running'`,
+        )
+        .run(nowIso());
+      const changed = Number((result as { changes?: number }).changes ?? 0);
+      if (changed > 0) {
+        console.log(
+          `[harness-mem] reconciled ${changed} abandoned consolidation job(s) left in running state`,
+        );
+      }
+    } catch {
+      // best effort — 起動を止めない
+    }
   }
 
   private seedFreshInstallEmbeddingDefault(hadHarnessSchemaBeforeInit: boolean): void {

--- a/memory-server/tests/unit/consolidation-abandoned-jobs.test.ts
+++ b/memory-server/tests/unit/consolidation-abandoned-jobs.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HarnessMemCore, getConfig } from "../../src/core/harness-mem-core";
+
+/**
+ * §160-004: daemon が job 実行中に落ちると `mem_consolidation_queue` の行が
+ * `running` のまま残り、誰も片付けないので単調に増える。
+ *
+ * 2026-07-28 の本番で 49 件の孤児が溜まっており (最古 2026-05-17、最新 2026-07-26)、
+ * これを見た調査エージェントが「worker pool がスタック」と誤診して本番 daemon の
+ * 再起動を推奨した。実際は 7 分で 3 件完了・pending 0 の健全な状態だった。
+ *
+ * 起動時に回収されることを固定する。
+ */
+describe("§160-004 起動時に abandoned consolidation job を回収する", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeCore(dbPath: string): HarnessMemCore {
+    return new HarnessMemCore({
+      ...getConfig(),
+      dbPath,
+      backgroundWorkersEnabled: false,
+    });
+  }
+
+  test("running のまま残った行を failed へ倒し、理由を残す", () => {
+    const dir = mkdtempSync(join(tmpdir(), "harness-mem-abandoned-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "t.db");
+
+    // 1 回目の起動でスキーマを作る
+    const first = makeCore(dbPath);
+    first.shutdown("test");
+
+    // daemon が job 実行中に落ちた状態を作る
+    const db = new Database(dbPath);
+    db.query(
+      `INSERT INTO mem_consolidation_queue(project, session_id, reason, status, requested_at, started_at)
+       VALUES (?, ?, ?, 'running', ?, ?)`,
+    ).run("p", "s1", "finalize", "2026-06-25T00:00:00.000Z", "2026-06-25T00:00:01.000Z");
+    db.query(
+      `INSERT INTO mem_consolidation_queue(project, session_id, reason, status, requested_at, started_at)
+       VALUES (?, ?, ?, 'running', ?, ?)`,
+    ).run("p", "s2", "dreaming", "2026-07-26T00:00:00.000Z", "2026-07-26T00:00:01.000Z");
+    // 完了済みの行は触られてはいけない
+    db.query(
+      `INSERT INTO mem_consolidation_queue(project, session_id, reason, status, requested_at, finished_at)
+       VALUES (?, ?, ?, 'completed', ?, ?)`,
+    ).run("p", "s3", "finalize", "2026-07-01T00:00:00.000Z", "2026-07-01T00:00:05.000Z");
+    // pending は次サイクルで拾われるので触られてはいけない
+    db.query(
+      `INSERT INTO mem_consolidation_queue(project, session_id, reason, status, requested_at)
+       VALUES (?, ?, ?, 'pending', ?)`,
+    ).run("p", "s4", "finalize", "2026-07-27T00:00:00.000Z");
+    db.close(false);
+
+    // 2 回目の起動で回収される
+    const second = makeCore(dbPath);
+    try {
+      const verify = new Database(dbPath, { readonly: true });
+      const counts = verify
+        .query(`SELECT status, count(*) AS n FROM mem_consolidation_queue GROUP BY status`)
+        .all() as Array<{ status: string; n: number }>;
+      const byStatus = Object.fromEntries(counts.map((r) => [r.status, r.n]));
+
+      expect(byStatus.running ?? 0).toBe(0);
+      expect(byStatus.failed).toBe(2);
+      // 他の状態は変えない
+      expect(byStatus.completed).toBe(1);
+      expect(byStatus.pending).toBe(1);
+
+      const failed = verify
+        .query(`SELECT error, finished_at FROM mem_consolidation_queue WHERE status = 'failed'`)
+        .all() as Array<{ error: string; finished_at: string }>;
+      for (const row of failed) {
+        // 何が起きたか分かる理由を残す (単なる failed だと原因が読めない)
+        expect(row.error).toContain("abandoned");
+        expect(row.finished_at).toBeTruthy();
+      }
+      verify.close(false);
+    } finally {
+      second.shutdown("test");
+    }
+  });
+
+  test("running が無ければ何も変えない (冪等)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "harness-mem-abandoned-noop-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "t.db");
+
+    const first = makeCore(dbPath);
+    first.shutdown("test");
+
+    const db = new Database(dbPath);
+    db.query(
+      `INSERT INTO mem_consolidation_queue(project, session_id, reason, status, requested_at, finished_at)
+       VALUES (?, ?, ?, 'completed', ?, ?)`,
+    ).run("p", "s1", "finalize", "2026-07-01T00:00:00.000Z", "2026-07-01T00:00:05.000Z");
+    db.close(false);
+
+    const second = makeCore(dbPath);
+    try {
+      const verify = new Database(dbPath, { readonly: true });
+      const row = verify
+        .query(`SELECT status, error FROM mem_consolidation_queue`)
+        .get() as { status: string; error: string | null };
+      expect(row.status).toBe("completed");
+      expect(row.error).toBeNull();
+      verify.close(false);
+    } finally {
+      second.shutdown("test");
+    }
+  });
+});


### PR DESCRIPTION
## 症状

`/v1/admin/consolidation/status` の `running_jobs` が実態と乖離し、**調査を誤らせます**。

実際に今日それが起きました。調査エージェントが `running_jobs=50` を見て「worker pool がスタックしている」と判断し、**本番 daemon の再起動を推奨**しました。

## 実際の状態(8 分の観測)

```
22:31 completed=11186 running=50 pending=2
22:34 completed=11188 running=50 pending=0
22:37 completed=11189 running=49 pending=0
```

7 分で 3 件完了、pending は 0 に捌けており **健全**でした。1 job あたり約 2.3 分かかるため、数秒の観測窓では「完了 0 件」に見えるのが誤診の原因です。

## 原因

consolidation は daemon プロセス内で走ります。SIGKILL / crash / launchd の再起動で中断されると `mem_consolidation_queue` の行が `running` のまま残り、誰も片付けません。

本番 DB の孤児 49 件の内訳です。

| 開始日 | 件数 |
|---|---|
| 2026-06-25 | 42(1 事故) |
| 2026-07-26 | 3 |
| 2026-07-24 / 07-19 / 05-19 / 05-17 | 各 1 |

**最新でも 2 日前**で、当日の行は 0 件。1 件も実行中ではありませんでした。

## 変更

起動時(`initSchema`)に `running` を `failed` へ倒し、`error` に理由を残します。

```
abandoned: daemon restarted while job was running
```

起動した時点で前プロセスの job は生きていないため安全です(lock file で多重起動を防ぐ単一プロセス設計が前提)。`completed` / `pending` は触りません。

## 検証

| 対象 | 結果 |
|---|---|
| 新規 test | **2 passed**(回収の動作 / `running` が無ければ何も変えない冪等性) |
| `npm test` | **3294 passed / 0 failed (exit 0)** |
| typecheck | PASS |

テストでは `completed` と `pending` の行を混ぜて置き、それらが変更されないことも固定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpnahrTWrJ2DPZhesch6dZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 起動時に放置された統合ジョブを検出し、失敗状態として記録するようになりました。
  * 処理終了時刻とエラー理由を保存し、管理画面上の実行中ジョブ情報との不一致を解消します。
  * 完了済み・保留中のジョブは変更されず、繰り返し実行しても安全です。

* **テスト**
  * 放置ジョブの回収、既存状態の維持、冪等性を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->