### PR TITLE
fix(consolidation): 回収を daemon 本体に限定する (§160-004 follow-up)

### DIFF
--- a/memory-server/src/core/harness-mem-core.ts
+++ b/memory-server/src/core/harness-mem-core.ts
@@ -1704,6 +1704,31 @@ function computeAntigravityWorkspaceRoots(config: {
   return [];
 }
 
+/**
+ * 現在のプロセスが「軽量 child」かどうか。
+ *
+ * search / checkpoint / event / retry / stats / recall / vector / materialize の
+ * 各 child は、親と同じ DB に対して `HarnessMemCore` を生成する。したがって
+ * child でも `initSchema()` や `shutdown()` が走る。**親 daemon の状態を書き換える
+ * 処理は child で実行してはならない** (例: 実行中 consolidation job の回収、
+ * retry queue の flush)。
+ *
+ * 判定は各 child が spawn 時に注入する env フラグで行う。
+ */
+export function isLightweightChildProcess(): boolean {
+  return (
+    process.env.HARNESS_MEM_SEARCH_CHILD_PROCESS === "1" ||
+    process.env.HARNESS_MEM_SEARCH_WORKER_PROCESS === "1" ||
+    process.env.HARNESS_MEM_CHECKPOINT_CHILD_PROCESS === "1" ||
+    process.env.HARNESS_MEM_EVENT_CHILD_PROCESS === "1" ||
+    process.env.HARNESS_MEM_RETRY_CHILD_PROCESS === "1" ||
+    process.env.HARNESS_MEM_PROJECTS_STATS_CHILD_PROCESS === "1" ||
+    process.env.HARNESS_MEM_RECALL_PROJECTION_REFRESH_CHILD === "1" ||
+    process.env.HARNESS_MEM_VECTOR_BACKFILL_CHILD === "1" ||
+    process.env.HARNESS_MEM_OBSERVATION_MATERIALIZE_CHILD === "1"
+  );
+}
+
 export class HarnessMemCore {
   private readonly storage: StorageAdapter;
   private readonly db: Database;
@@ -2633,6 +2658,13 @@ export class HarnessMemCore {
    * 理由を残す。単一プロセス設計 (lock file で多重起動を防いでいる) が前提。
    */
   private reconcileAbandonedConsolidationJobs(): void {
+    // 子プロセス (search / checkpoint / event / retry / stats / recall / vector /
+    // materialize) も同じ DB に対して HarnessMemCore を作るため initSchema が走る。
+    // そこで回収すると、**親 daemon が実行中の job を failed に誤更新する**。
+    // 回収は daemon 本体の起動時だけに限定する (2026-07-28 review 指摘)。
+    if (isLightweightChildProcess()) {
+      return;
+    }
     try {
       const result = this.db
         .query(
@@ -9520,16 +9552,7 @@ export class HarnessMemCore {
       return;
     }
     this.shuttingDown = true;
-    const lightweightChild =
-      process.env.HARNESS_MEM_SEARCH_CHILD_PROCESS === "1" ||
-      process.env.HARNESS_MEM_SEARCH_WORKER_PROCESS === "1" ||
-      process.env.HARNESS_MEM_CHECKPOINT_CHILD_PROCESS === "1" ||
-      process.env.HARNESS_MEM_EVENT_CHILD_PROCESS === "1" ||
-      process.env.HARNESS_MEM_RETRY_CHILD_PROCESS === "1" ||
-      process.env.HARNESS_MEM_PROJECTS_STATS_CHILD_PROCESS === "1" ||
-      process.env.HARNESS_MEM_RECALL_PROJECTION_REFRESH_CHILD === "1" ||
-      process.env.HARNESS_MEM_VECTOR_BACKFILL_CHILD === "1" ||
-      process.env.HARNESS_MEM_OBSERVATION_MATERIALIZE_CHILD === "1";
+    const lightweightChild = isLightweightChildProcess();
 
     for (const timer of this.recallProjectionRefreshTimers.values()) {
       clearTimeout(timer);

--- a/memory-server/tests/unit/consolidation-abandoned-jobs.test.ts
+++ b/memory-server/tests/unit/consolidation-abandoned-jobs.test.ts
@@ -92,6 +92,42 @@ describe("§160-004 起動時に abandoned consolidation job を回収する", (
     }
   });
 
+  test("軽量 child プロセスでは回収しない (親の実行中 job を壊さない)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "harness-mem-abandoned-child-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "t.db");
+
+    const first = makeCore(dbPath);
+    first.shutdown("test");
+
+    // 親 daemon が実行中の job を模す
+    const db = new Database(dbPath);
+    db.query(
+      `INSERT INTO mem_consolidation_queue(project, session_id, reason, status, requested_at, started_at)
+       VALUES (?, ?, ?, 'running', ?, ?)`,
+    ).run("p", "s1", "finalize", "2026-07-28T00:00:00.000Z", "2026-07-28T00:00:01.000Z");
+    db.close(false);
+
+    // child は同じ DB に対して HarnessMemCore を作るが、回収してはいけない
+    const original = process.env.HARNESS_MEM_SEARCH_CHILD_PROCESS;
+    process.env.HARNESS_MEM_SEARCH_CHILD_PROCESS = "1";
+    let child: HarnessMemCore | null = null;
+    try {
+      child = makeCore(dbPath);
+      const verify = new Database(dbPath, { readonly: true });
+      const row = verify
+        .query(`SELECT status FROM mem_consolidation_queue`)
+        .get() as { status: string };
+      // running のまま = 親の job を壊していない
+      expect(row.status).toBe("running");
+      verify.close(false);
+    } finally {
+      child?.shutdown("test");
+      if (original === undefined) delete process.env.HARNESS_MEM_SEARCH_CHILD_PROCESS;
+      else process.env.HARNESS_MEM_SEARCH_CHILD_PROCESS = original;
+    }
+  });
+
   test("running が無ければ何も変えない (冪等)", () => {
     const dir = mkdtempSync(join(tmpdir(), "harness-mem-abandoned-noop-"));
     dirs.push(dir);


### PR DESCRIPTION
## PR #164 の穴を塞ぎます

#164 で「起動時に `running` のまま残った consolidation job を回収する」処理を入れました。**その処理が子プロセスでも走る**という指摘を受け、修正します。

## 何が問題だったか

search / checkpoint / event / retry / stats / recall / vector / materialize の各 child プロセスは、**親と同じ DB に対して `HarnessMemCore` を生成**します。したがって child 起動時にも `initSchema()` が走ります。

その結果、**親 daemon が実行中の job を `failed` に誤更新する**経路がありました。

```
親 daemon: consolidation job A を実行中 (status=running)
        ↓
子プロセス起動 (例: search-child)
        ↓
initSchema() → 回収処理が走る
        ↓
job A が failed に (実際は実行中)
```

## 変更

1. lightweight child 判定を `isLightweightChildProcess()` として切り出し、`shutdown()` 内のインライン判定と共通化(重複実装を削除)
2. `reconcileAbandonedConsolidationJobs` は child では即 `return`

判定は各 child が spawn 時に注入する env フラグ(`HARNESS_MEM_*_CHILD_PROCESS`)です。`shutdown()` が既に同じ判定で retry queue の flush 等をスキップしており、その規約に合わせました。

## 検証

| 対象 | 結果 |
|---|---|
| 新規 test | child 環境で `running` が維持されること(親の job を壊さない)を追加 |
| 当該ファイル | **3 passed** |
| `npm test` | **3295 passed / 0 failed (exit 0)** |
| typecheck | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpnahrTWrJ2DPZhesch6dZ