### PR TITLE
chore(release): v0.29.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.29.3",
+      "version": "0.29.4",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.4] - 2026-07-29
+
+### Fixed
+
+- **The daemon keeps answering `/health` while it ingests history**: `bun:sqlite` is a synchronous FFI binding, so every scheduled ingest tick blocked the event loop for as long as its SQLite work took, and the HTTP server could not answer during that window. The three history paths (`claude_code`, `codex`, `cursor`) now read in slices under a per-tick time budget, so a long tick yields instead of running to completion. Tunable through `HARNESS_MEM_INGEST_TICK_BUDGET_MS` (default 200), `HARNESS_MEM_INGEST_MAX_BYTES_PER_FILE` (default 512KB, previously 2MB) and `HARNESS_MEM_INGEST_READ_SLICE_BYTES` (default 64KB). Measured on a 4.9GB production database with 4721 Codex session files: non-200 health responses went from 73 / 240 samples to 3 / 300, with p50 1ms and p95 14ms.
+- **Directory scanning and WAL checkpoints no longer block the same event loop**: enumerating `~/.codex/sessions` and `~/.claude/projects` took 3–10 seconds of synchronous `statSync` plus offset lookups on every tick, and `PRAGMA wal_checkpoint(PASSIVE)` ran synchronously every 60 seconds outside any measurement. Scanning is now inside the tick budget with a round-robin cursor so late files are not starved, and the checkpoint interval is configurable through `HARNESS_MEM_WAL_CHECKPOINT_INTERVAL_MS` (default 300s).
+- **Slow ticks are now visible instead of inferred**: each scheduled tick reports how long it held the event loop, logging only above `HARNESS_MEM_SLOW_TICK_LOG_MS` (default 1000) so a healthy daemon stays quiet. This log named the responsible subsystem in one restart, after symptom-based reasoning had produced two wrong diagnoses.
+- **A busy daemon is no longer treated as a dead one**: the Go MCP proxy answered a health timeout by starting a second daemon, which then contended for the same database. It now checks whether the recorded pid is alive, waits up to 10 seconds, and reports that the daemon is busy rather than launching a competitor.
+- **Shutdown always terminates**: `SIGTERM` handling could stall before the WAL checkpoint and `db.close()`, leaving the process alive and the port held. A watchdog now forces exit after `HARNESS_MEM_SHUTDOWN_TIMEOUT_MS` (default 10000), and the retry-queue drain no longer skips the remaining shutdown steps when it throws.
+- **`harness-memd stop` reports failure when it fails**: the stop path escalated `SIGTERM` to `SIGKILL` but returned success unconditionally, so a surviving process was reported as stopped and the caller cleaned up state that was still in use. It now re-checks liveness after escalation and refuses to clean up when the process is still running.
+- **Consolidation jobs left `running` by a crashed daemon are reconciled at startup**: rows stayed `running` forever and accumulated (49 orphans observed, oldest from 2026-05-17), which made the queue look stuck when it was not. They are now marked `failed` with an explicit reason. Lightweight child processes skip this reconciliation so they cannot invalidate the parent daemon's in-flight jobs.
+- **`npm test` no longer depends on whether the developer machine runs Ollama**: `tests/benchmarks/s108-developer-domain-manifest.test.ts` reached a real local LLM through the deep freshness bench, where a single reconcile took 203 seconds. It is disabled by default under `NODE_ENV=test` and can be re-enabled explicitly. The session-start parity contract also clears inherited `CLAUDE_PLUGIN_DATA` before spawning, so a host session's plugin data directory cannot change the result.
+
+### Documentation
+
+- **Added `docs/daemon-health-runbook.md`**: how to tell a busy daemon from a hung one, why the first case resolves itself, the stop procedure for the second, how to read the slow-tick log, the tuning environment variables, and the reasoning behind the probe defaults.
+
+### Verification
+
+- Repository behavior gate (`npm test`): 3295 passed, 0 failed.
+- Production health probe after the change set: 3 non-200 responses out of 300 samples, p50 1ms / p95 14ms / p99 0.97s.
+
+### Known limits
+
+- One indivisible unit of work — parsing a single slice, or a single `recordEvent` — cannot be interrupted by the tick budget, and its cost scales with database size rather than payload size. On an empty database a 70KB payload costs 55ms; on the 4.9GB production database the same shape produced 11-second ticks. Tracked as §160.
+
 ## [0.29.3] - 2026-07-26
 
 ### Fixed
@@ -3129,7 +3155,8 @@ Setup and feed browsing became easier through an interactive setup flow and inli
 - Run `harness-mem setup` and confirm interactive prompts appear in sequence.
 - Open feed UI and confirm card details expand inline.
 
-[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.3...HEAD
+[Unreleased]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.4...HEAD
+[0.29.4]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.3...v0.29.4
 [0.29.3]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.2...v0.29.3
 [0.29.2]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/Chachamaru127/harness-mem/compare/v0.29.0...v0.29.1

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,6 +7,32 @@
 
 ## [Unreleased]
 
+## [0.29.4] - 2026-07-29
+
+### 修正
+
+- **履歴 ingest 中でも daemon が `/health` に応答し続ける**。`bun:sqlite` は同期 FFI のため、定期 ingest の tick が SQLite 処理の間だけ event loop を占有し、その窓では HTTP サーバが応答できなかった。`claude_code` / `codex` / `cursor` の 3 経路をスライス読み込みに変え、tick ごとの時間 budget を超えたら次回に持ち越すようにした。調整は `HARNESS_MEM_INGEST_TICK_BUDGET_MS` (既定 200)、`HARNESS_MEM_INGEST_MAX_BYTES_PER_FILE` (既定 512KB、従来 2MB)、`HARNESS_MEM_INGEST_READ_SLICE_BYTES` (既定 64KB)。DB 4.9GB / Codex session 4721 ファイルの本番実測で、非 200 応答は 73 / 240 サンプルから 3 / 300 に減り、p50 1ms / p95 14ms。
+- **ファイル走査と WAL checkpoint も同じ budget の対象にした**。`~/.codex/sessions` と `~/.claude/projects` の全件列挙が毎 tick で同期 `statSync` + offset 参照に 3〜10 秒かかっており、`PRAGMA wal_checkpoint(PASSIVE)` は 60 秒ごとに計測外で同期実行されていた。走査は budget 内に入れ、round-robin cursor で末尾のファイルが飢えないようにした。checkpoint 間隔は `HARNESS_MEM_WAL_CHECKPOINT_INTERVAL_MS` (既定 300 秒) で調整できる。
+- **遅い tick を推測ではなく計測で特定できるようにした**。各 tick が event loop を保持した時間を記録し、`HARNESS_MEM_SLOW_TICK_LOG_MS` (既定 1000) 超過時のみ出力する。平常時は無音。症状からの推論では 2 回誤診したが、このログでは再起動 1 回で原因の subsystem が名指しされた。
+- **busy な daemon を死んだ daemon として扱わない**。Go の MCP proxy が health タイムアウトに対して 2 つ目の daemon を起動し、同じ DB を奪い合っていた。記録された pid の生存を確認し、最大 10 秒待ったうえで「busy である」と報告するようにした。
+- **shutdown が必ず終わる**。`SIGTERM` 処理が WAL checkpoint と `db.close()` の手前で停止し、プロセスと port が残ることがあった。`HARNESS_MEM_SHUTDOWN_TIMEOUT_MS` (既定 10000) で強制終了する watchdog を追加し、retry queue の drain が例外を投げても残りの停止手順を飛ばさないようにした。
+- **`harness-memd stop` が失敗を失敗として返す**。`SIGTERM` → `SIGKILL` のエスカレーション後も無条件に成功を返していたため、生存中のプロセスを「停止した」と報告し、まだ使用中の状態を呼び出し側が片付けていた。エスカレーション後に生存を再確認し、残っている場合は cleanup しない。
+- **daemon が落ちて `running` のまま残った consolidation job を起動時に回収する**。回収する主体がいないため単調に増え (孤児 49 件、最古 2026-05-17)、queue が詰まっているように見えていた。理由付きで `failed` に倒す。軽量 child プロセスでは実行しないので、親 daemon の実行中 job を壊さない。
+- **`npm test` の合否が開発機の Ollama 有無に依存しなくなった**。`tests/benchmarks/s108-developer-domain-manifest.test.ts` が deep freshness bench 経由で実 LLM を呼び、reconcile 1 回に 203 秒かかっていた。`NODE_ENV=test` では既定 OFF とし、明示指定で有効化できる。session-start parity contract も spawn 前に継承した `CLAUDE_PLUGIN_DATA` を消すため、host セッションの plugin data ディレクトリが結果を変えない。
+
+### ドキュメント
+
+- **`docs/daemon-health-runbook.md` を追加**。busy な daemon とハングした daemon の見分け方、前者が自力回復する理由、後者の停止手順、slow tick ログの読み方、調整用の環境変数、probe 既定値の根拠を記載した。
+
+### 検証
+
+- リリース内容に対する repository behavior gate (`npm test`): 3295 passed / 0 failed。
+- 本番 health probe (変更適用後): 300 サンプル中 非 200 が 3 件、p50 1ms / p95 14ms / p99 0.97s。
+
+### 既知の限界
+
+- 分割できない 1 単位の処理 (1 スライスの parse、1 件の `recordEvent`) は tick budget で中断できず、そのコストは payload サイズではなく DB サイズに律速される。空 DB では 70KB payload が 55ms なのに、本番 4.9GB DB では同じ形で tick が 11 秒になった。§160 で追跡中。
+
 ## [0.29.3] - 2026-07-26
 
 ### 修正

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.29.3",
+      "version": "0.29.4",
       "license": "BUSL-1.1",
       "dependencies": {
         "@huggingface/transformers": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## 概要

v0.29.3 以降 main に入っている 16 commit（§159 の daemon 応答性修正 + §160-004 の consolidation job 回収）を配布可能にするためのバージョン切り出し。コード変更はなく、版面と CHANGELOG のみ。

## 変更

- 版面 6 箇所を 0.29.4 に統一
  - `package.json`
  - `package-lock.json` ×2
  - `.claude-plugin/plugin.json`
  - `.claude-plugin/marketplace.json` ×2
- `CHANGELOG.md` に 0.29.4 エントリ + 比較リンク参照
- `CHANGELOG_ja.md` に対応する日本語要約

## ローカル再現したリリースゲート

v0.29.2 は tag と GitHub Release まで進みながらレジストリ側に届かなかった。原因は `publish-npm` job のみが通る gate が長期間 CI 未到達で陳腐化していたこと。同じ失敗を避けるため、`release.yml` の該当 job の全ステップをタグ前にローカルで再現した。

| ゲート | 結果 |
|---|---|
| `npm test`（repository behavior gate） | 3295 passed / 0 failed |
| `npm pack --dry-run` | 0.29.4 / 623 files / 5.4MB |
| harness-mem-ui test / typecheck | 48 passed / 0 error |
| memory-server typecheck | 0 error |
| benchmark（locomo-120 / bilingual-50 / knowledge-update / temporal） | PASSED（locomo token avg 462.98 ≤ 500） |
| Developer-domain gate | PASSED（dev recall@10 0.7708 ≥ 0.70 / bilingual 0.8200 ≥ 0.82 / freshness 0.9900 ≥ 0.95 / temporal 0.8575 ≥ 0.70） |
| Inject actionability gate | PASSED（tier=green） |
| WorkGraph release gate | PASSED（mode=enforce / tier=green） |
| Recall Runtime gate | PASSED（`--enforce`） |

ベンチマークが書き換えた成果物ファイルは restore 済みで、本 PR の diff は版面と CHANGELOG のみ。

## マージ後

`v0.29.4` タグを main 上のマージコミットに付けて push すると `release.yml` が起動する。タグ push は人手承認が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 同期処理中も `/health` が応答しやすくなり、ヘルスチェックの遅延を改善しました。
  - シャットダウン、停止処理、クラッシュ後のジョブ復旧に関する問題を修正しました。
  - 遅い同期処理を特定しやすいログを追加しました。
  - テストがローカル環境の特定サービス有無に依存しないよう改善しました。

- **ドキュメント**
  - デーモンのヘルスチェック手順を追加しました。

- **リリース**
  - バージョンを 0.29.4 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->