### PR TITLE
chore: release v0.29.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cross-tool persistent memory runtime for AI coding agents (Claude Code, Codex, Cursor, OpenCode)",
-    "version": "0.29.4",
+    "version": "0.29.5",
     "homepage": "https://github.com/Chachamaru127/harness-mem"
   },
   "plugins": [
@@ -17,7 +17,7 @@
         "repo": "Chachamaru127/harness-mem"
       },
       "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with hybrid search",
-      "version": "0.29.4",
+      "version": "0.29.5",
       "author": {
         "name": "Chachamaru",
         "email": "chachamaru@harness-mem.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mem",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "description": "Persistent memory system for AI coding sessions — cross-tool memory sharing with 6-dimensional hybrid search",
   "author": {
     "name": "Chachamaru",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.5] - 2026-08-03
+
+### Fixed
+
+- **A single `recordEvent` no longer gets slower as the database grows**: the auto-linker's lookup filtered on `session_id`, but the only index covering that column led with `project`, so SQLite fell back to a full index scan whose cost rose with row count. Measured across three database tiers, that one query went from 0.057ms on an empty database to 31.459ms on a 4.9GB one — 80.6% of the whole `recordEvent` call, a 551.9x spread. Adding `idx_mem_obs_session_created ON mem_observations(session_id, created_at, id)` turns the scan into a seek: at the 1GB tier the segment went 5.502ms → 0.034ms (162x) and end-to-end `recordEvent` went 11.894ms → 3.575ms. The auto-linker's `ORDER BY created_at DESC` also gained an `id DESC` tie-break, so two observations sharing a timestamp resolve deterministically instead of by scan order.
+- **Periodic ingest can no longer block the event loop for minutes**: 0.29.4 added a per-tick time budget, but six ingest paths loaded an entire input into memory before the first budget check could fire, so the cost was already paid by the time the budget was consulted. On the shipped 0.29.4 the production daemon was observed blocking a single synchronous call for 173,528ms (codex), 60,354ms (cursor) and 38,718ms (claude_code), with 27 ticks over 10 seconds. All six paths — the legacy Codex history file, both OpenCode paths (database and storage), both Antigravity paths (workspace and logs), and Gemini — now read in slices under the tick budget with an independent per-run read cap. The OpenCode database path bounds its query with `LIMIT` rather than reading every row in the backfill window. The Antigravity workspace parser needs whole files, so that path enforces a size cap and skips oversized files instead of reading them, warning once per file rather than on every tick. A secondary input read on the Antigravity log path (`exthost.log`, consulted once per file visit to resolve the workspace) was also unbounded and is now capped.
+- **Explicitly requested ingest runs to completion again**: `POST /v1/ingest/cursor-history` returned after 50 events, or after 200ms, whichever came first. The scheduler and the HTTP endpoint called the same function, so the per-tick budget added in 0.29.4 applied to the manual call as well — a caller asking for a full catch-up got a partial one with no indication it had been cut short. The same fusion was about to ship for Antigravity and Gemini. All three now separate the scheduled path from the endpoint, and the endpoint is bounded by neither time nor count, which is what `Spec.md` has always specified for explicit ingest.
+- **A cut-short ingest run no longer loses records**: three paths (OpenCode storage, Antigravity logs, Gemini) advanced the persisted ingest offset past entries whose `recordEvent` had not completed. Any run that stopped early — on a write failure or a budget cut — moved the offset over unprocessed entries, which were then never read again. Each path now advances the offset only over the byte range whose writes actually succeeded, and does not create an offset row at all when nothing was consumed, so a file that fails on its first entry keeps its backfill-window eligibility instead of being re-read on every tick forever.
+
+### Changed
+
+- **The repository behavior gate now runs on every pull request**: `npm test` was wired only into the release workflow's publish job, which is gated on a tag push. Nothing verified the suite at review time, so failures surfaced during a release instead of during the change that caused them — the same shape as the v0.29.2 publish failure. A `Test Suite` workflow now runs the same gate on every `pull_request` (deliberately without a path filter, because the gate checks repository-wide contracts) and on pushes to `main`. It found a real failure on its first run, and another during this release's own review cycle.
+- **`Spec.md`'s periodic ingest contract now bounds the fan-out, not just each input**: a timer that pulls a variable number of inputs — operator-configured or discovered at runtime — must share one budget across them rather than give each a full one, since otherwise the worst-case block scales with that count.
+
+### Verification
+
+- Repository behavior gate (`npm test`) on the merged state: 3333 tests, 0 failed.
+- The budget coverage check is now a regression lock over every `runTick`-reachable ingest path rather than three named ones. A second, independent lock asserts that no function the HTTP routes expose as explicit ingest is also registered as a scheduled tick — the fusion described above would fail it. Both locks were verified to fail when the corresponding fix is reverted.
+
+### Known limits
+
+- The production effect of the ingest bounding is not yet confirmed. The pre-change measurement (173,528ms peak) came from the running 0.29.4 daemon; the post-change comparison requires this release to be deployed.
+- `recordEvent`'s per-call cost on the actual 18.9GB production database has not been measured. The tiers above top out at 4.9GB.
+- The budget coverage lock matches budget references in source text, so it does not prove the budget takes effect at runtime, and breaking only one of two references is not detected. Its limits are recorded in the test itself.
+
 ## [0.29.4] - 2026-07-29
 
 ### Fixed

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,6 +7,31 @@
 
 ## [Unreleased]
 
+## [0.29.5] - 2026-08-03
+
+### 修正
+
+- **`recordEvent` 1 件のコストが DB サイズに比例して悪化する問題を解消した**。auto-linker の検索は `session_id` で絞るが、その列を含む唯一のインデックスは先頭列が `project` だったため、SQLite がインデックス全体を走査していた。この 1 クエリは空 DB で 0.057ms、4.9GB DB で 31.459ms (recordEvent 全体の 80.6%、比 551.9 倍)。`idx_mem_obs_session_created` を追加して走査を探索に変えた結果、1GB tier で 5.502ms → 0.034ms (162 倍)、E2E も 11.894ms → 3.575ms。`ORDER BY created_at DESC` に `id DESC` の tie-break を足し、同時刻の 2 件が走査順に依存しないようにした。
+- **定期 ingest が event loop を数分間占有しなくなった**。0.29.4 で tick ごとの時間 budget を入れたが、6 経路は入力全体をメモリに読み込んでから処理するため、最初の budget チェックが走る時点でコストを払い終えていた。稼働中の 0.29.4 で codex 173,528ms / cursor 60,354ms / claude_code 38,718ms、10 秒超 27 件を実測。legacy Codex 履歴 / OpenCode 2 経路 / Antigravity 2 経路 / Gemini のすべてを、budget 内のスライス読み込みと経路ごとの読み込み上限に変えた。OpenCode DB 経路は `LIMIT` でクエリ自体を有界にした。Antigravity workspace は parser が全文を要求するため、サイズ上限を超えるファイルは読まずにスキップし、警告はファイルごとに初回 1 回だけ出す。Antigravity log 経路が 1 ファイル訪問ごとに読む二次入力 (`exthost.log`) も無制限だったので上限を入れた。
+- **明示的に要求した ingest が再び完走する**。`POST /v1/ingest/cursor-history` は 50 件、または 200ms のどちらか早い方で打ち切って返っていた。scheduler と HTTP endpoint が同じ関数を呼んでいたため、0.29.4 で入れた tick budget が手動呼び出しにも効いていた。全件取り込みを求めた呼び出し側は、打ち切られたことを知る手段がないまま部分的な結果を受け取っていた。同じ融合が Antigravity と Gemini でも出荷される寸前だった。3 経路とも scheduler 用の経路を分離し、endpoint 側は時間でも件数でも打ち切らない (Spec.md が当初から定めていた契約)。
+- **途中で打ち切られた ingest が記録を落とさなくなった**。OpenCode storage / Antigravity logs / Gemini の 3 経路が、`recordEvent` 未完了の entry より先へ offset を進めていた。書き込み失敗や budget 打ち切りで中断すると、未処理分が二度と読まれず静かに消えていた。offset は書き込みが成功した範囲に対してのみ進め、消費 0 バイトのときは offset 行自体を作らない (作ると backfill window の判定が恒久的に無効化される)。
+
+### 変更
+
+- **repository behavior gate (`npm test`) を全 PR で実行するようにした**。この gate は release workflow の publish job にしか配線されておらず、tag push まで一度も走らなかった。レビュー時点で誰も検証できず、失敗はリリース直前に初めて表面化していた (v0.29.2 の publish 失敗と同型)。`Test Suite` workflow を追加し、すべての `pull_request` (path filter なし。gate はリポジトリ全体の契約を見るため) と `main` への push で同じ gate を走らせる。初回実行で実際の失敗を検出し、今回のリリースのレビュー中にもさらに 1 件検出した。
+- **`Spec.md` の定期 ingest 契約が、入力ごとだけでなく fan-out 自体も有界にすることを求めるようにした**。timer が引く入力数が可変 (operator 設定または実行時発見) の場合、各入力に満額の budget を与えると最悪ブロックがその数に比例するため、budget を共有しなければならない。
+
+### 検証
+
+- マージ後の状態に対する repository behavior gate (`npm test`): 3333 件、失敗 0。
+- budget 網羅検査を、名指しの 3 経路ではなく `runTick` から到達する全経路に広げた。加えて独立した 2 つ目の lock が「HTTP が明示 ingest として公開している関数を scheduler が tick に登録していないこと」を固定する (上記の融合はこれで落ちる)。どちらも対応する修正を戻すと落ちることを実測で確認した。
+
+### 既知の限界
+
+- 本番での効果は未確認。修正前の 173,528ms は稼働中の 0.29.4 の実測で、修正後の比較にはこのリリースの反映が要る。
+- 本番の 18.9GB DB での `recordEvent` 単価は未計測 (上記 tier は 4.9GB まで)。
+- budget 網羅検査はソース文字列上の budget 参照を見るため、実行時に budget が効くことは保証しない。2 つある参照の片方だけを潰しても検出できない。この限界はテスト本体に明記してある。
+
 ## [0.29.4] - 2026-07-29
 
 ### 修正

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chachamaru127/harness-mem",
-      "version": "0.29.4",
+      "version": "0.29.5",
       "license": "BUSL-1.1",
       "dependencies": {
         "@huggingface/transformers": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chachamaru127/harness-mem",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "description": "Memory bridge for Claude Code and Codex — local-first, zero-cost coding memory runtime",
   "homepage": "https://github.com/Chachamaru127/harness-mem",
   "repository": {


### PR DESCRIPTION
## 内容

3 PR 分をまとめて出す。

| PR | 内容 |
|---|---|
| #167 | §160-001/002/003 — `recordEvent` のコスト下限を特定し、index 追加で潰す |
| #169 | §160-005 + §160-008 — 定期 ingest の無制限ループ + `npm test` を PR で走らせる |
| #170 | §160-007 — 残る 5 経路の budget 対応 + 明示 API の打ち切り回帰 |

## この PR 自体の変更

version surface 6 箇所と CHANGELOG 2 本のみ。コード変更なし。

- `package.json` / `package-lock.json` ×2
- `.claude-plugin/plugin.json` / `.claude-plugin/marketplace.json` ×2
- `CHANGELOG.md` / `CHANGELOG_ja.md`

## 検証

- `npm test`: exit 0 / 3333 件 / 失敗 0（#170 の CI と一致）
- `npm pack --dry-run`: 0.29.5 の tarball を確認（628 files / 5.4MB）
- `tests/marketplace-schema.test.ts`: 22 pass（version 一致検査）

## 注意: 公開クレームを 1 件据え置いている

README の `Bilingual recall@10 = 0.9000` は、現行コードが出す値（実測 0.82）と一致していない。160-006 として起票済みで、**2026-07-30 の operator 裁定により「CI で再測定してから公開値を決める」**方針。ローカル 1 回の実行を根拠に外部公開クレームを動かさないため、このリリースでは据え置く。

claim 検査（README と manifest の一致）は manifest 側も 0.9000 のままなので通る。リリース自体はブロックされない。

## 未達として残るもの

- **160-005d**: 本番ログでの効果確認。修正前は codex 173,528ms。反映後の比較にはこのリリースのデプロイが要る
- 本番 18.9GB DB での `recordEvent` 単価は未計測（測定した tier は 4.9GB まで）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn4noqDmxyd2QezsMzYguT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - バージョンを **0.29.5** に更新しました。
  - 手動実行のデータ取り込みが、時間・件数制限の影響を受けず完了するようになりました。

- **バグ修正**
  - 定期取り込みの処理量を適切に制御し、大容量ファイルやログによる負荷を軽減しました。
  - 取り込み途中で終了した場合も、成功した範囲のみ進捗を更新するよう改善しました。
  - 自動リンク検索の性能と結果の安定性を向上しました。

- **ドキュメント**
  - 変更内容、検証結果、既知の制限をリリースノートに追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->